### PR TITLE
getUserByUsername() now valid on v5

### DIFF
--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -42,15 +42,10 @@ trait Users
      * Get a user from their username
      *
      * @param string $username
-     * @throws EndpointNotSupportedByApiVersionException
      * @return array|json
      */
     public function getUserByUsername($username)
     {
-        if (!$this->apiVersionIsGreaterThanV4()) {
-            throw new EndpointNotSupportedByApiVersionException();
-        }
-
         $params = [
             'login' => $username,
         ];


### PR DESCRIPTION
Per https://discuss.dev.twitch.tv/t/twitch-api-version-update-discussion-faq/8132 they added back the users/?login= endpoint for v5. Removed the check for v4 or lower.