### PR TITLE
Add refresh token

### DIFF
--- a/src/Api/Authentication.php
+++ b/src/Api/Authentication.php
@@ -42,4 +42,20 @@ trait Authentication
             'state' => $state,
         ]);
     }
+
+    /**
+     * Get a new access token
+     *
+     * @param string $refreshToken
+     * @return array|json
+     */
+    public function refreshToken($refreshToken)
+    {
+        return $this->post('oauth2/token', [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refreshToken,
+            'client_id' => $this->getClientId(),
+            'client_secret' => $this->getClientSecret(),
+        ]);
+    }
 }


### PR DESCRIPTION
Oauth2 twitch's tokens have now an expiration date, and they must be refresh after a time.
I add the implementation of that.

See twitch's documentation:
[Refreshing access tokens](https://dev.twitch.tv/docs/authentication#refreshing-access-tokens)