### PR TITLE
Fixed getTopClips() always failing

### DIFF
--- a/src/Api/Clips.php
+++ b/src/Api/Clips.php
@@ -54,7 +54,7 @@ trait Clips
             }
 
             $channel = trim($channel, ', ');
-            if ($count = count(explode(',', $channel) > 10)) {
+            if (($count = count(explode(',', $channel)) > 10)) {
                 throw new TwitchApiException(sprintf('Only a maximum of 10 channels can be queried. %d requested.', $count));
             }
         }


### PR DESCRIPTION
Without the parentheses when checking for the number of channels, the statement will always evaluate to true. That makes the method unusable.