### PR TITLE
Have oauth2 requests use Twitch's new authentication endpoint

### DIFF
--- a/src/Api/Authentication.php
+++ b/src/Api/Authentication.php
@@ -58,4 +58,18 @@ trait Authentication
             'client_secret' => $this->getClientSecret(),
         ]);
     }
+
+    /**
+     * Revoke an access token
+     *
+     * @param string $accessToken
+     * @return array|json
+     */
+    public function revokeToken($accessToken)
+    {
+        return $this->post('oauth2/revoke', [
+            'client_id' => $this->getClientId(),
+            'token' => $accessToken,
+        ]);
+    }
 }

--- a/src/Api/Authentication.php
+++ b/src/Api/Authentication.php
@@ -14,7 +14,7 @@ trait Authentication
     public function getAuthenticationUrl($state = null, $forceVerify = false)
     {
         return implode('', [
-            sprintf('%soauth2/authorize', $this->baseUri),
+            sprintf('%soauth2/authorize', $this->authUri),
             '?response_type=code',
             sprintf('&client_id=%s', $this->getClientId()),
             sprintf('&redirect_uri=%s', $this->getRedirectUri()),

--- a/src/TwitchRequest.php
+++ b/src/TwitchRequest.php
@@ -14,7 +14,12 @@ class TwitchRequest
     /**
      * @var string
      */
-    protected $baseUri = 'https://api.twitch.tv/kraken/';
+    protected $apiUri = 'https://api.twitch.tv/kraken/';
+
+    /**
+     * @var string
+     */
+    protected $authUri = 'https://id.twitch.tv/';
 
     /**
      * @var float
@@ -47,7 +52,7 @@ class TwitchRequest
      */
     protected function sendRequest($method, $endpoint, $params = [], $accessToken = null)
     {
-        $client = $this->getNewHttpClient($method, $params, $accessToken);
+        $client = $this->getNewHttpClient($method, $params, $endpoint, $accessToken);
         $response = $client->request($method, $endpoint);
         $responseBody = $response->getBody()->getContents();
 
@@ -59,14 +64,15 @@ class TwitchRequest
      *
      * @param strring $method
      * @param array   $params
+     * @param string  $endpoint
      * @param string  $accessToken
-     * @return Client
+     * @return GuzzleHttp\Client
      */
-    protected function getNewHttpClient($method, $params, $accessToken = null)
+    protected function getNewHttpClient($method, $params, $endpoint, $accessToken = null)
     {
         $config = [
             'http_errors' => $this->getHttpErrors(),
-            'base_uri' => $this->baseUri,
+            'base_uri' => $this->getBaseUri($endpoint),
             'timeout' => $this->getTimeout(),
             'headers' => [
                 'Client-ID' => $this->getClientId(),
@@ -84,6 +90,21 @@ class TwitchRequest
         }
 
         return new GuzzleHttp\Client($config);
+    }
+
+    /**
+     * Returns the correct base URL depending on the provided endpoint
+     *
+     * @param string $endpoint
+     * @return string
+     */
+    private function getBaseUri($endpoint)
+    {
+        if(strpos($endpoint, 'oauth2') !== false) {
+            return $this->authUri;
+        }
+
+        return $this->apiUri;
     }
 
     /**


### PR DESCRIPTION
- All oauth2 endpoint now use https://id.twitch.tv instead of https://api.twitch.tv/kraken.
- Added revokeToken method for revoking access tokens

Closes #15 