### PR TITLE
Reduce the complexity of mapping query params

### DIFF
--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -36,20 +36,73 @@ abstract class AbstractResource
      * $queryParamsMap should be a mapping of the param key expected in the API call URL,
      * and the value to be sent for that key.
      *
-     * [['key' => 'param_key', 'value' => 42],['key' => 'other_key', 'value' => 'asdf']]
-     * would result in
-     * ?param_key=42&other_key=asdf
+     * For example, the following array:
+     *
+     * [
+     *   'int_key'    => 42,
+     *   'bool_key'   => true,
+     *   'string_key' => 'twitch',
+     *   'array_key'  => ['is', 'number', 1],
+     * ]
+     *
+     * would result in the following query params:
+     *
+     *  ?int_key=42&bool_key=true&string_key=twitch&array_key=is&array_key=number&array_key=1
      */
     protected function generateQueryParams(array $queryParamsMap): string
     {
         $queryStringParams = '';
-        foreach ($queryParamsMap as $paramMap) {
-            if ($paramMap['value']) {
-                $format = is_int($paramMap['value']) ? '%d' : '%s';
-                $queryStringParams .= sprintf('&%s='.$format, $paramMap['key'], $paramMap['value']);
+
+        foreach ($queryParamsMap as $key => $value) {
+            switch (gettype($value)) {
+                case 'string':
+                    $this->appendStringToQuery($queryStringParams, $key, $value);
+                    break;
+                case 'integer':
+                    $this->appendIntegerToQuery($queryStringParams, $key, $value);
+                    break;
+                case 'boolean':
+                    $this->appendBooleanToQuery($queryStringParams, $key, $value);
+                    break;
+                case 'array':
+                    $this->appendArrayToQuery($queryStringParams, $key, $value);
+                    break;
+                default:
+                    break;
             }
         }
 
-        return $queryStringParams ? '?'.substr($queryStringParams, 1) : '';
+        return $queryStringParams ? '?' . substr($queryStringParams, 1) : '';
+    }
+
+    private function appendStringToQuery(string &$queryStringParams, string $key, string $value): void
+    {
+        if ($value !== '') {
+            $queryStringParams .= sprintf('&%s=%s', $key, $value);
+        }
+    }
+
+    private function appendIntegerToQuery(string &$queryStringParams, string $key, int $value): void
+    {
+        $queryStringParams .= sprintf('&%s=%d', $key, $value);
+    }
+
+    private function appendBooleanToQuery(string &$queryStringParams, string $key, bool $value): void
+    {
+        $boolString = $value ? 'true' : 'false';
+        $queryStringParams .= sprintf('&%s=%s', $key, $boolString);
+    }
+
+    private function appendArrayToQuery(string &$queryStringParams, string $key, array $value): void
+    {
+        foreach ($value as $v) {
+            $vType = gettype($v);
+            if (!in_array($vType, ['string', 'integer'])) {
+                continue;
+            }
+
+            $format = $vType === 'integer' ? '%d' : '%s';
+            $queryStringParams .= sprintf('&%s=' . $format, $key, $v);
+        }
     }
 }

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -54,47 +54,54 @@ abstract class AbstractResource
         $queryStringParams = '';
 
         foreach ($queryParamsMap as $key => $value) {
-            switch (gettype($value)) {
-                case 'string':
-                    $this->appendStringToQuery($queryStringParams, $key, $value);
-                    break;
-                case 'integer':
-                    $this->appendIntegerToQuery($queryStringParams, $key, $value);
-                    break;
-                case 'boolean':
-                    $this->appendBooleanToQuery($queryStringParams, $key, $value);
-                    break;
-                case 'array':
-                    $this->appendArrayToQuery($queryStringParams, $key, $value);
-                    break;
-                default:
-                    break;
-            }
+            $queryStringParams .= $this->generateQueryStringFragment($key, $value);
         }
 
         return $queryStringParams ? '?' . substr($queryStringParams, 1) : '';
     }
 
-    private function appendStringToQuery(string &$queryStringParams, string $key, string $value): void
+    /**
+     * @param mixed $value
+     */
+    private function generateQueryStringFragment(string $key, $value): string
     {
-        if ($value !== '') {
-            $queryStringParams .= sprintf('&%s=%s', $key, $value);
+        switch (gettype($value)) {
+            case 'string':
+                return $this->generateStringFragment($key, $value);
+            case 'integer':
+                return $this->generateIntegerFragment($key, $value);
+            case 'boolean':
+                return $this->generateBooleanFragment($key, $value);
+            case 'array':
+                return $this->generateArrayFragement($key, $value);
+            default:
+                return '';
         }
     }
 
-    private function appendIntegerToQuery(string &$queryStringParams, string $key, int $value): void
+    private function generateStringFragment(string $key, string $value): string
     {
-        $queryStringParams .= sprintf('&%s=%d', $key, $value);
+        if ($value !== '') {
+            return sprintf('&%s=%s', $key, $value);
+        }
+
+        return '';
     }
 
-    private function appendBooleanToQuery(string &$queryStringParams, string $key, bool $value): void
+    private function generateIntegerFragment(string $key, int $value): string
+    {
+        return sprintf('&%s=%d', $key, $value);
+    }
+
+    private function generateBooleanFragment(string $key, bool $value): string
     {
         $boolString = $value ? 'true' : 'false';
-        $queryStringParams .= sprintf('&%s=%s', $key, $boolString);
+        return sprintf('&%s=%s', $key, $boolString);
     }
 
-    private function appendArrayToQuery(string &$queryStringParams, string $key, array $value): void
+    private function generateArrayFragement(string $key, array $value): string
     {
+        $arrayString = '';
         foreach ($value as $v) {
             $vType = gettype($v);
             if (!in_array($vType, ['string', 'integer'])) {
@@ -102,7 +109,9 @@ abstract class AbstractResource
             }
 
             $format = $vType === 'integer' ? '%d' : '%s';
-            $queryStringParams .= sprintf('&%s=' . $format, $key, $v);
+            $arrayString .= sprintf('&%s=' . $format, $key, $v);
         }
+
+        return $arrayString;
     }
 }

--- a/src/NewTwitchApi/Resources/GamesApi.php
+++ b/src/NewTwitchApi/Resources/GamesApi.php
@@ -15,13 +15,10 @@ class GamesApi extends AbstractResource
      */
     public function getGames(array $ids = [], array $names = []): ResponseInterface
     {
-        $queryParamsMap = [];
-        foreach ($ids as $id) {
-            $queryParamsMap[] = ['key' => 'id', 'value' => $id];
-        }
-        foreach ($names as $name) {
-            $queryParamsMap[] = ['key' => 'name', 'value' => $name];
-        }
+        $queryParamsMap = [
+            'id' => $ids,
+            'name' => $names,
+        ];
 
         return $this->callApi('games', $queryParamsMap);
     }

--- a/src/NewTwitchApi/Resources/StreamsApi.php
+++ b/src/NewTwitchApi/Resources/StreamsApi.php
@@ -29,33 +29,26 @@ class StreamsApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-streams
      */
-    public function getStreams(array $userIds = [], array $usernames = [], array $gameIds = [], array $communityIds = [], array $languages = [], int $first = null, string $before = null, string $after = null): ResponseInterface
-    {
-        $queryParamsMap = [];
-        foreach ($userIds as $id) {
-            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-        }
-        foreach ($usernames as $username) {
-            $queryParamsMap[] = ['key' => 'user_login', 'value' => $username];
-        }
-        foreach ($gameIds as $gameId) {
-            $queryParamsMap[] = ['key' => 'game_id', 'value' => $gameId];
-        }
-        foreach ($communityIds as $communityId) {
-            $queryParamsMap[] = ['key' => 'community_id', 'value' => $communityId];
-        }
-        foreach ($languages as $language) {
-            $queryParamsMap[] = ['key' => 'language', 'value' => $language];
-        }
-        if ($first) {
-            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-        }
-        if ($before) {
-            $queryParamsMap[] = ['key' => 'before', 'value' => $before];
-        }
-        if ($after) {
-            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-        }
+    public function getStreams(
+        array $userIds = [],
+        array $usernames = [],
+        array $gameIds = [],
+        array $communityIds = [],
+        array $languages = [],
+        int $first = null,
+        string $before = null,
+        string $after = null
+    ): ResponseInterface {
+        $queryParamsMap = [
+            'user_id' => $userIds,
+            'user_login' => $usernames,
+            'game_id' => $gameIds,
+            'community_id' => $communityIds,
+            'language' => $languages,
+            'first' => $first,
+            'before' => $before,
+            'after' => $after,
+        ];
 
         return $this->callApi('streams', $queryParamsMap);
     }

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -12,37 +12,36 @@ class UsersApi extends AbstractResource
     /**
      * @throws GuzzleException
      */
-    public function getUserByAccessToken(string $accessToken, bool $includeEmail = false): ResponseInterface
+    public function getUserByAccessToken(string $accessToken): ResponseInterface
     {
-        return $this->getUsers([], [], $includeEmail, $accessToken);
+        return $this->getUsers([], [], $accessToken);
     }
 
     /**
      * @throws GuzzleException
      */
-    public function getUserById(int $id, bool $includeEmail = false): ResponseInterface
+    public function getUserById(int $id): ResponseInterface
     {
-        return $this->getUsers([$id], [], $includeEmail);
+        return $this->getUsers([$id], []);
     }
 
     /**
      * @throws GuzzleException
      */
-    public function getUserByUsername(string $username, bool $includeEmail = false): ResponseInterface
+    public function getUserByUsername(string $username): ResponseInterface
     {
-        return $this->getUsers([], [$username], $includeEmail);
+        return $this->getUsers([], [$username]);
     }
 
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-users
      */
-    public function getUsers(array $ids = [], array $usernames = [], bool $includeEmail = false, string $bearer = null): ResponseInterface
+    public function getUsers(array $ids = [], array $usernames = [], string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [
             'id' => $ids,
             'login' => $usernames,
-            'scope' => true === $includeEmail ? 'user:read:email' : '',
         ];
 
         return $this->callApi('users', $queryParamsMap, $bearer);

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -39,16 +39,11 @@ class UsersApi extends AbstractResource
      */
     public function getUsers(array $ids = [], array $usernames = [], bool $includeEmail = false, string $bearer = null): ResponseInterface
     {
-        $queryParamsMap = [];
-        foreach ($ids as $id) {
-            $queryParamsMap[] = ['key' => 'id', 'value' => $id];
-        }
-        foreach ($usernames as $username) {
-            $queryParamsMap[] = ['key' => 'login', 'value' => $username];
-        }
-        if ($includeEmail) {
-            $queryParamsMap[] = ['key' => 'scope', 'value' => 'user:read:email'];
-        }
+        $queryParamsMap = [
+            'id' => $ids,
+            'login' => $usernames,
+            'scope' => true === $includeEmail ? 'user:read:email' : '',
+        ];
 
         return $this->callApi('users', $queryParamsMap, $bearer);
     }
@@ -59,19 +54,12 @@ class UsersApi extends AbstractResource
      */
     public function getUsersFollows(int $followerId = null, int $followedUserId = null, int $first = null, string $after = null): ResponseInterface
     {
-        $queryParamsMap = [];
-        if ($followerId) {
-            $queryParamsMap[] = ['key' => 'from_id', 'value' => $followerId];
-        }
-        if ($followedUserId) {
-            $queryParamsMap[] = ['key' => 'to_id', 'value' => $followedUserId];
-        }
-        if ($first) {
-            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-        }
-        if ($after) {
-            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-        }
+        $queryParamsMap = [
+            'from_id' => $followerId,
+            'to_id' => $followedUserId,
+            'first' => $first,
+            'after' => $after,
+        ];
 
         return $this->callApi('users/follows', $queryParamsMap);
     }

--- a/src/NewTwitchApi/Resources/WebhooksApi.php
+++ b/src/NewTwitchApi/Resources/WebhooksApi.php
@@ -15,13 +15,10 @@ class WebhooksApi extends AbstractResource
      */
     public function getWebhookSubscriptions(string $accessToken, int $first = null, string $after = null): ResponseInterface
     {
-        $queryParamsMap = [];
-        if ($first) {
-            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-        }
-        if ($after) {
-            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-        }
+        $queryParamsMap = [
+            'first' => $first,
+            'after' => $after,
+        ];
 
         return $this->callApi('webhooks/subscriptions', $queryParamsMap, $accessToken);
     }


### PR DESCRIPTION
- **Reduce the complexity of mapping query params** - I think this implementation is much cleaner and more maintainable. 

- **Don't include scope param in getUsers request** -  Scopes are implicitly bound to access tokens, thus it is not required that they be included in individual request params.