### PR TITLE
Use string instead of int for IDs.

### DIFF
--- a/spec/NewTwitchApi/Cli/CliEndpoints/GetGamesCliEndpointSpec.php
+++ b/spec/NewTwitchApi/Cli/CliEndpoints/GetGamesCliEndpointSpec.php
@@ -25,9 +25,9 @@ class GetGamesCliEndpointSpec extends ObjectBehavior
 
     function it_should_get_games_by_ids_and_names(NewTwitchApi $newTwitchApi, InputReader $inputReader, GamesApi $gamesApi)
     {
-        $gamesApi->getGames([12345, 98765], ['game1', 'game2'])->shouldBeCalled();
+        $gamesApi->getGames(['12345', '98765'], ['game1', 'game2'])->shouldBeCalled();
         $newTwitchApi->getGamesApi()->willReturn($gamesApi);
-        $inputReader->readCSVIntoArrayFromStdin()->willReturn([12345, 98765], ['game1', 'game2']);
+        $inputReader->readCSVIntoArrayFromStdin()->willReturn(['12345', '98765'], ['game1', 'game2']);
 
         $this->execute();
     }

--- a/spec/NewTwitchApi/Cli/CliEndpoints/GetStreamsCliEndpointSpec.php
+++ b/spec/NewTwitchApi/Cli/CliEndpoints/GetStreamsCliEndpointSpec.php
@@ -26,7 +26,7 @@ class GetStreamsCliEndpointSpec extends ObjectBehavior
     function it_should_get_streams(NewTwitchApi $newTwitchApi, InputReader $inputReader, StreamsApi $streamsApi)
     {
         $streamsApi->getStreams(
-            [12345, 98765],
+            ['12345', '98765'],
             ['user1', 'user2'],
             ['game1', 'game2'],
             ['community1', 'community2'],
@@ -37,7 +37,7 @@ class GetStreamsCliEndpointSpec extends ObjectBehavior
         )->shouldBeCalled();
         $newTwitchApi->getStreamsApi()->willReturn($streamsApi);
         $inputReader->readCSVIntoArrayFromStdin()->willReturn(
-            [12345, 98765],
+            ['12345', '98765'],
             ['user1', 'user2'],
             ['game1', 'game2'],
             ['community1', 'community2'],

--- a/spec/NewTwitchApi/Cli/CliEndpoints/GetUsersCliEndpointSpec.php
+++ b/spec/NewTwitchApi/Cli/CliEndpoints/GetUsersCliEndpointSpec.php
@@ -25,9 +25,9 @@ class GetUsersCliEndpointSpec extends ObjectBehavior
 
     function it_should_get_games_by_ids_and_names_with_email(NewTwitchApi $newTwitchApi, InputReader $inputReader, UsersApi $usersApi)
     {
-        $usersApi->getUsers([12345, 98765], ['game1', 'game2'], true)->shouldBeCalled();
+        $usersApi->getUsers(['12345', '98765'], ['game1', 'game2'], true)->shouldBeCalled();
         $newTwitchApi->getUsersApi()->willReturn($usersApi);
-        $inputReader->readCSVIntoArrayFromStdin()->willReturn([12345, 98765], ['game1', 'game2']);
+        $inputReader->readCSVIntoArrayFromStdin()->willReturn(['12345', '98765'], ['game1', 'game2']);
         $inputReader->readFromStdin()->willReturn('y');
 
         $this->execute();
@@ -35,9 +35,9 @@ class GetUsersCliEndpointSpec extends ObjectBehavior
 
     function it_should_get_games_by_ids_and_names_without_email(NewTwitchApi $newTwitchApi, InputReader $inputReader, UsersApi $usersApi)
     {
-        $usersApi->getUsers([12345, 98765], ['game1', 'game2'], false)->shouldBeCalled();
+        $usersApi->getUsers(['12345', '98765'], ['game1', 'game2'], false)->shouldBeCalled();
         $newTwitchApi->getUsersApi()->willReturn($usersApi);
-        $inputReader->readCSVIntoArrayFromStdin()->willReturn([12345, 98765], ['game1', 'game2']);
+        $inputReader->readCSVIntoArrayFromStdin()->willReturn(['12345', '98765'], ['game1', 'game2']);
         $inputReader->readFromStdin()->willReturn('n');
 
         $this->execute();

--- a/spec/NewTwitchApi/Cli/CliEndpoints/GetUsersFollowsCliEndpointSpec.php
+++ b/spec/NewTwitchApi/Cli/CliEndpoints/GetUsersFollowsCliEndpointSpec.php
@@ -25,10 +25,10 @@ class GetUsersFollowsCliEndpointSpec extends ObjectBehavior
 
     function it_should_get_games_by_ids_and_names_with_email(NewTwitchApi $newTwitchApi, InputReader $inputReader, UsersApi $usersApi)
     {
-        $usersApi->getUsersFollows(12345, 98765, 100, 'after')->shouldBeCalled();
+        $usersApi->getUsersFollows('12345', '98765', 100, 'after')->shouldBeCalled();
         $newTwitchApi->getUsersApi()->willReturn($usersApi);
-        $inputReader->readIntFromStdin()->willReturn(12345, 98765, 100);
-        $inputReader->readFromStdin()->willReturn('after');
+        $inputReader->readFromStdin()->willReturn('12345', '98765', 'after');
+        $inputReader->readIntFromStdin()->willReturn(100);
 
         $this->execute();
     }

--- a/spec/NewTwitchApi/Resources/GamesApiSpec.php
+++ b/spec/NewTwitchApi/Resources/GamesApiSpec.php
@@ -18,7 +18,7 @@ class GamesApiSpec extends ObjectBehavior
     function it_should_get_games_by_ids(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'games?id=12345&id=98765'))->willReturn($response);
-        $this->getGames([12345,98765])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getGames(['12345','98765'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_games_by_names(Client $guzzleClient, Response $response)
@@ -30,6 +30,6 @@ class GamesApiSpec extends ObjectBehavior
     function it_should_get_games_by_ids_and_names(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'games?id=12345&id=98765&name=mario&name=sonic'))->willReturn($response);
-        $this->getGames([12345,98765], ['mario','sonic'])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getGames(['12345','98765'], ['mario','sonic'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 }

--- a/spec/NewTwitchApi/Resources/StreamsApiSpec.php
+++ b/spec/NewTwitchApi/Resources/StreamsApiSpec.php
@@ -18,7 +18,7 @@ class StreamsApiSpec extends ObjectBehavior
     function it_should_get_streams_by_ids(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'streams?user_id=12345&user_id=98765'))->willReturn($response);
-        $this->getStreams([12345,98765])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getStreams(['12345','98765'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_streams_by_usernames(Client $guzzleClient, Response $response)
@@ -30,13 +30,13 @@ class StreamsApiSpec extends ObjectBehavior
     function it_should_get_streams_by_id_and_username(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'streams?user_id=12345&user_id=98765&user_login=twitchuser&user_login=anotheruser'))->willReturn($response);
-        $this->getStreams([12345,98765], ['twitchuser','anotheruser'])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getStreams(['12345','98765'], ['twitchuser','anotheruser'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_a_single_user_by_id(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'streams?user_id=12345'))->willReturn($response);
-        $this->getStreamForUserId(12345)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getStreamForUserId('12345')->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_a_single_user_by_username(Client $guzzleClient, Response $response)
@@ -48,13 +48,13 @@ class StreamsApiSpec extends ObjectBehavior
     function it_should_get_streams_by_game_ids(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'streams?game_id=12345&game_id=98765'))->willReturn($response);
-        $this->getStreams([], [], [12345,98765])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getStreams([], [], ['12345','98765'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_streams_by_community_ids(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'streams?community_id=12345&community_id=98765'))->willReturn($response);
-        $this->getStreams([], [], [], [12345,98765])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getStreams([], [], [], ['12345','98765'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_streams_by_languages(Client $guzzleClient, Response $response)
@@ -84,6 +84,6 @@ class StreamsApiSpec extends ObjectBehavior
     function it_should_get_streams_by_everything(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'streams?user_id=12&user_id=34&user_login=twitchuser&user_login=anotheruser&game_id=56&game_id=78&community_id=90&community_id=99&language=en&language=de&first=100&before=200&after=300'))->willReturn($response);
-        $this->getStreams([12,34], ['twitchuser','anotheruser'], [56,78], [90,99], ['en','de'], 100, 200, 300)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getStreams(['12','34'], ['twitchuser','anotheruser'], ['56','78'], ['90','99'], ['en','de'], 100, 200, 300)->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 }

--- a/spec/NewTwitchApi/Resources/UsersApiSpec.php
+++ b/spec/NewTwitchApi/Resources/UsersApiSpec.php
@@ -18,7 +18,7 @@ class UsersApiSpec extends ObjectBehavior
     function it_should_get_users_by_ids(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users?id=12345&id=98765'))->willReturn($response);
-        $this->getUsers([12345,98765])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUsers(['12345','98765'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_users_by_usernames(Client $guzzleClient, Response $response)
@@ -30,13 +30,13 @@ class UsersApiSpec extends ObjectBehavior
     function it_should_get_users_by_id_and_username(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users?id=12345&id=98765&login=twitchuser&login=anotheruser'))->willReturn($response);
-        $this->getUsers([12345,98765], ['twitchuser','anotheruser'])->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUsers(['12345','98765'], ['twitchuser','anotheruser'])->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_a_single_user_by_id(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users?id=12345'))->willReturn($response);
-        $this->getUserById(12345)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUserById('12345')->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_a_single_user_by_username(Client $guzzleClient, Response $response)
@@ -54,25 +54,25 @@ class UsersApiSpec extends ObjectBehavior
     function it_should_get_users_by_everything_including_email(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users?id=12345&id=98765&login=twitchuser&login=anotheruser&scope=user:read:email'))->willReturn($response);
-        $this->getUsers([12345,98765], ['twitchuser','anotheruser'], true)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUsers(['12345','98765'], ['twitchuser','anotheruser'], true)->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_users_follows_by_follower_id(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users/follows?from_id=12345'))->willReturn($response);
-        $this->getUsersFollows(12345)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUsersFollows('12345')->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_users_follows_by_followed_id(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users/follows?to_id=12345'))->willReturn($response);
-        $this->getUsersFollows(null, 12345)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUsersFollows(null, '12345')->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_users_follows_by_follower_id_and_followed_id(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users/follows?from_id=12345&to_id=98765'))->willReturn($response);
-        $this->getUsersFollows(12345, 98765)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUsersFollows('12345', '98765')->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_users_follows_page_by_first(Client $guzzleClient, Response $response)
@@ -90,7 +90,7 @@ class UsersApiSpec extends ObjectBehavior
     function it_should_get_users_follows_by_everything(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users/follows?from_id=12345&to_id=98765&first=42&after=99'))->willReturn($response);
-        $this->getUsersFollows(12345, 98765, 42, 99)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUsersFollows('12345', '98765', 42, 99)->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 
     function it_should_get_user_with_access_token(Client $guzzleClient, Response $response)
@@ -102,6 +102,6 @@ class UsersApiSpec extends ObjectBehavior
     function it_should_get_user_with_access_token_convenience_method(Client $guzzleClient, Response $response)
     {
         $guzzleClient->send(new Request('GET', 'users', ['Authorization' => 'Bearer access-token']))->willReturn($response);
-        $this->getUserByAccessToken('access-token', false)->shouldBeAnInstanceOf(ResponseInterface::class);
+        $this->getUserByAccessToken('access-token')->shouldBeAnInstanceOf(ResponseInterface::class);
     }
 }

--- a/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
+++ b/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
@@ -38,6 +38,6 @@ class WebhooksSubscriptionApiSpec extends ObjectBehavior
             'body' => '{"hub.callback":"https:\/\/redirect.url","hub.mode":"subscribe","hub.topic":"https:\/\/api.twitch.tv\/helix\/streams?user_id=12345","hub.lease_seconds":100,"hub.secret":"client-secret"}'
         ])->shouldBeCalled();
 
-        $this->subscribeToStream(12345, 'bearer-token', 'https://redirect.url', 100);
+        $this->subscribeToStream('12345', 'bearer-token', 'https://redirect.url', 100);
     }
 }

--- a/src/NewTwitchApi/Cli/CliEndpoints/GetUsersFollowsCliEndpoint.php
+++ b/src/NewTwitchApi/Cli/CliEndpoints/GetUsersFollowsCliEndpoint.php
@@ -16,9 +16,9 @@ class GetUsersFollowsCliEndpoint extends AbstractCliEndpoint
     public function execute(): ResponseInterface
     {
         $this->getOutputWriter()->write('Follower ID: ');
-        $followerId = $this->getInputReader()->readIntFromStdin();
+        $followerId = $this->getInputReader()->readFromStdin();
         $this->getOutputWriter()->write('Followed User ID: ');
-        $followedUserId = $this->getInputReader()->readIntFromStdin();
+        $followedUserId = $this->getInputReader()->readFromStdin();
         $this->getOutputWriter()->write('Max results to return: ');
         $first = $this->getInputReader()->readIntFromStdin();
         $this->getOutputWriter()->write('Cursor value next page starts with: ');

--- a/src/NewTwitchApi/Resources/StreamsApi.php
+++ b/src/NewTwitchApi/Resources/StreamsApi.php
@@ -12,7 +12,7 @@ class StreamsApi extends AbstractResource
     /**
      * @throws GuzzleException
      */
-    public function getStreamForUserId(int $userId): ResponseInterface
+    public function getStreamForUserId(string $userId): ResponseInterface
     {
         return $this->getStreams([$userId]);
     }

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -20,7 +20,7 @@ class UsersApi extends AbstractResource
     /**
      * @throws GuzzleException
      */
-    public function getUserById(int $id, bool $includeEmail = false): ResponseInterface
+    public function getUserById(string $id, bool $includeEmail = false): ResponseInterface
     {
         return $this->getUsers([$id], [], $includeEmail);
     }
@@ -57,7 +57,7 @@ class UsersApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-users-follows
      */
-    public function getUsersFollows(int $followerId = null, int $followedUserId = null, int $first = null, string $after = null): ResponseInterface
+    public function getUsersFollows(string $followerId = null, string $followedUserId = null, int $first = null, string $after = null): ResponseInterface
     {
         $queryParamsMap = [];
         if ($followerId) {

--- a/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
+++ b/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
@@ -22,7 +22,7 @@ class WebhooksSubscriptionApi
         $this->guzzleClient = $guzzleClient ?? new HelixGuzzleClient($clientId);
     }
 
-    public function subscribeToStream(int $twitchId, string $bearer, string $callback, int $leaseSeconds = 0): void
+    public function subscribeToStream(string $twitchId, string $bearer, string $callback, int $leaseSeconds = 0): void
     {
         $this->subscribe(
             sprintf('https://api.twitch.tv/helix/streams?user_id=%s', $twitchId),

--- a/test/NewTwitchApi/Resources/UsersTest.php
+++ b/test/NewTwitchApi/Resources/UsersTest.php
@@ -16,7 +16,7 @@ class UsersTest extends PHPUnit_Framework_TestCase
     public function testGetUserByIdShouldReturnSuccessfulResponseWithUserData(): void
     {
         $users = new UsersApi($this->getGuzzleClientWithMockUserResponse());
-        $response = $users->getUserById(44322889);
+        $response = $users->getUserById('44322889');
 
         $this->assertEquals(200, $response->getStatusCode());
         $contents = json_decode($response->getBody()->getContents());


### PR DESCRIPTION
Fixes #31 

This changes all IDs to be and expect strings instead of integers. 

I would consider this a breaking change, since I'm changing types in type-strict code. I think when this is released, we should bump to v2.1 instead of v2.0.1. This is major enough that it warrants it, but not major enough to be a v3. Anyone who specifically has 2.0.1 or generic ^2.0 in their composer.json will be fine. Anyone who just has ^2 is kinda asking for trouble anyway and should be aware that they might have issues when upgrading a package like this. (Hopefully those assumingly few will catch this is dev, QA, or CI first. Not sure how we could get the word out. Thoughts?