### PR TITLE
Make bearer token optional when subscribing to webhooks

### DIFF
--- a/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
+++ b/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
@@ -66,4 +66,16 @@ class WebhooksSubscriptionApiSpec extends ObjectBehavior
 
         $this->subscribeToUserFollows('12345', '54321', 1, 'bearer-token', 'https://redirect.url', 100);
     }
+
+    function it_subscribes_to_a_user_without_bearer(Client $guzzleClient)
+    {
+        $guzzleClient->post('webhooks/hub', [
+            'headers' => [
+                'Client-ID' => 'client-id',
+            ],
+            'body' => '{"hub.callback":"https:\/\/redirect.url","hub.mode":"subscribe","hub.topic":"https:\/\/api.twitch.tv\/helix\/users\/follows?from_id=12345&to_id=54321&first=1","hub.lease_seconds":100,"hub.secret":"client-secret"}'
+        ])->shouldBeCalled();
+
+        $this->subscribeToUserFollows('12345', '54321', 1, null, 'https://redirect.url', 100);
+    }
 }

--- a/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
+++ b/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
@@ -38,7 +38,7 @@ class WebhooksSubscriptionApiSpec extends ObjectBehavior
             'body' => '{"hub.callback":"https:\/\/redirect.url","hub.mode":"subscribe","hub.topic":"https:\/\/api.twitch.tv\/helix\/streams?user_id=12345","hub.lease_seconds":100,"hub.secret":"client-secret"}'
         ])->shouldBeCalled();
 
-        $this->subscribeToStream('12345', 'bearer-token', 'https://redirect.url', 100);
+        $this->subscribeToStream('12345', 'https://redirect.url', 'bearer-token', 100);
     }
 
     function it_subscribes_to_a_user(Client $guzzleClient)
@@ -51,7 +51,7 @@ class WebhooksSubscriptionApiSpec extends ObjectBehavior
             'body' => '{"hub.callback":"https:\/\/redirect.url","hub.mode":"subscribe","hub.topic":"https:\/\/api.twitch.tv\/helix\/users?id=12345","hub.lease_seconds":100,"hub.secret":"client-secret"}'
         ])->shouldBeCalled();
 
-        $this->subscribeToUser('12345', 'bearer-token', 'https://redirect.url', 100);
+        $this->subscribeToUser('12345', 'https://redirect.url', 'bearer-token', 100);
     }
 
     function it_subscribes_to_user_follows(Client $guzzleClient)
@@ -64,7 +64,7 @@ class WebhooksSubscriptionApiSpec extends ObjectBehavior
             'body' => '{"hub.callback":"https:\/\/redirect.url","hub.mode":"subscribe","hub.topic":"https:\/\/api.twitch.tv\/helix\/users\/follows?from_id=12345&to_id=54321&first=1","hub.lease_seconds":100,"hub.secret":"client-secret"}'
         ])->shouldBeCalled();
 
-        $this->subscribeToUserFollows('12345', '54321', 1, 'bearer-token', 'https://redirect.url', 100);
+        $this->subscribeToUserFollows('12345', '54321', 1, 'https://redirect.url', 'bearer-token', 100);
     }
 
     function it_subscribes_to_a_user_without_bearer(Client $guzzleClient)
@@ -76,6 +76,6 @@ class WebhooksSubscriptionApiSpec extends ObjectBehavior
             'body' => '{"hub.callback":"https:\/\/redirect.url","hub.mode":"subscribe","hub.topic":"https:\/\/api.twitch.tv\/helix\/users\/follows?from_id=12345&to_id=54321&first=1","hub.lease_seconds":100,"hub.secret":"client-secret"}'
         ])->shouldBeCalled();
 
-        $this->subscribeToUserFollows('12345', '54321', 1, null, 'https://redirect.url', 100);
+        $this->subscribeToUserFollows('12345', '54321', 1, 'https://redirect.url', null, 100);
     }
 }

--- a/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
+++ b/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
@@ -22,7 +22,7 @@ class WebhooksSubscriptionApi
         $this->guzzleClient = $guzzleClient ?? new HelixGuzzleClient($clientId);
     }
 
-    public function subscribeToStream(string $twitchId, string $bearer, string $callback, int $leaseSeconds = 0): void
+    public function subscribeToStream(string $twitchId, string $bearer = null, string $callback, int $leaseSeconds = 0): void
     {
         $this->subscribe(
             sprintf('https://api.twitch.tv/helix/streams?user_id=%s', $twitchId),
@@ -32,7 +32,7 @@ class WebhooksSubscriptionApi
         );
     }
 
-    public function subscribeToUser(string $twitchId, string $bearer, string $callback, int $leaseSeconds = 0): void
+    public function subscribeToUser(string $twitchId, string $bearer = null, string $callback, int $leaseSeconds = 0): void
     {
         $this->subscribe(
             sprintf('https://api.twitch.tv/helix/users?id=%s', $twitchId),
@@ -42,7 +42,7 @@ class WebhooksSubscriptionApi
         );
     }
 
-    public function subscribeToUserFollows(string $followerId, string $followedUserId, int $first, string $bearer, string $callback, int $leaseSeconds = 0): void
+    public function subscribeToUserFollows(string $followerId, string $followedUserId, int $first, string $bearer = null, string $callback, int $leaseSeconds = 0): void
     {
         $queryParams = [];
         if ($followerId) {
@@ -70,12 +70,14 @@ class WebhooksSubscriptionApi
         return $expectedHash === $generatedHash;
     }
 
-    private function subscribe(string $topic, string $bearer, string $callback, int $leaseSeconds = 0): void
+    private function subscribe(string $topic, string $bearer = null, string $callback, int $leaseSeconds = 0): void
     {
         $headers = [
-            'Authorization' => sprintf('Bearer %s', $bearer),
             'Client-ID' => $this->clientId,
         ];
+        if (!is_null($bearer)) {
+            $headers['Authorization'] = sprintf('Bearer %s', $bearer);
+        }
 
         $body = [
             'hub.callback' => $callback,

--- a/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
+++ b/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
@@ -22,27 +22,27 @@ class WebhooksSubscriptionApi
         $this->guzzleClient = $guzzleClient ?? new HelixGuzzleClient($clientId);
     }
 
-    public function subscribeToStream(string $twitchId, string $bearer = null, string $callback, int $leaseSeconds = 0): void
+    public function subscribeToStream(string $twitchId, string $callback, string $bearer = null, int $leaseSeconds = 0): void
     {
         $this->subscribe(
             sprintf('https://api.twitch.tv/helix/streams?user_id=%s', $twitchId),
-            $bearer,
             $callback,
+            $bearer,
             $leaseSeconds
         );
     }
 
-    public function subscribeToUser(string $twitchId, string $bearer = null, string $callback, int $leaseSeconds = 0): void
+    public function subscribeToUser(string $twitchId, string $callback, string $bearer = null, int $leaseSeconds = 0): void
     {
         $this->subscribe(
             sprintf('https://api.twitch.tv/helix/users?id=%s', $twitchId),
-            $bearer,
             $callback,
+            $bearer,
             $leaseSeconds
         );
     }
 
-    public function subscribeToUserFollows(string $followerId, string $followedUserId, int $first, string $bearer = null, string $callback, int $leaseSeconds = 0): void
+    public function subscribeToUserFollows(string $followerId, string $followedUserId, int $first, string $callback, string $bearer = null, int $leaseSeconds = 0): void
     {
         $queryParams = [];
         if ($followerId) {
@@ -56,8 +56,8 @@ class WebhooksSubscriptionApi
         }
         $this->subscribe(
             sprintf('https://api.twitch.tv/helix/users/follows?%s', http_build_query($queryParams)),
-            $bearer,
             $callback,
+            $bearer,
             $leaseSeconds
         );
     }
@@ -70,7 +70,7 @@ class WebhooksSubscriptionApi
         return $expectedHash === $generatedHash;
     }
 
-    private function subscribe(string $topic, string $bearer = null, string $callback, int $leaseSeconds = 0): void
+    private function subscribe(string $topic, string $callback, string $bearer = null, int $leaseSeconds = 0): void
     {
         $headers = [
             'Client-ID' => $this->clientId,


### PR DESCRIPTION
Currently the webhook API type-hints the bearer token as a string, which makes it impossible to not use a bearer token. 

The documentation implies it may be needed, but does not make it mandatory for all topics:
https://dev.twitch.tv/docs/api/webhooks-guide#subscriptions

>Subscription denied — In this case, the request payload explains why the subscription could not be created. **For example, you may not be authorized to access the resource you requested** or you may have exceeded the maximum number of subscriptions.

Currently the only place it is required is the [user changed](https://dev.twitch.tv/docs/api/webhooks-reference/#topic-user-changed) topic when retrieving the email:
>This webhook requires the user:read:email OAuth scope, to get notifications of email changes.

This PR makes the parameter default to null, allowing null to be used.
