### PR TITLE
Optional Authentication for Users API and Broadcasters Subscriptions

### DIFF
--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -9,6 +9,7 @@ use NewTwitchApi\Auth\OauthApi;
 use NewTwitchApi\Resources\GamesApi;
 use NewTwitchApi\Resources\StreamsApi;
 use NewTwitchApi\Resources\UsersApi;
+use NewTwitchApi\Resources\SubscriptionsApi;
 use NewTwitchApi\Resources\WebhooksApi;
 use NewTwitchApi\Webhooks\WebhooksSubscriptionApi;
 
@@ -18,6 +19,7 @@ class NewTwitchApi
     private $gamesApi;
     private $streamsApi;
     private $usersApi;
+    private $subscriptionsApi;
     private $webhooksApi;
     private $webhooksSubscriptionApi;
 
@@ -27,6 +29,7 @@ class NewTwitchApi
         $this->gamesApi = new GamesApi($helixGuzzleClient);
         $this->streamsApi = new StreamsApi($helixGuzzleClient);
         $this->usersApi = new UsersApi($helixGuzzleClient);
+        $this->subscriptionsApi = new SubscriptionsApi($helixGuzzleClient);
         $this->webhooksApi = new WebhooksApi($helixGuzzleClient);
         $this->webhooksSubscriptionApi = new WebhooksSubscriptionApi($clientId, $clientSecret, $helixGuzzleClient);
     }
@@ -49,6 +52,11 @@ class NewTwitchApi
     public function getUsersApi(): UsersApi
     {
         return $this->usersApi;
+    }
+
+    public function getSubscriptionsApi(): UsersApi
+    {
+        return $this->subscriptionsApi;
     }
 
     public function getWebhooksApi(): WebhooksApi

--- a/src/NewTwitchApi/Resources/SubscriptionsApi.php
+++ b/src/NewTwitchApi/Resources/SubscriptionsApi.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class SubscriptionsApi extends AbstractResource
+{
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
+     */
+    public function getBroadcasterSubscriptions(string $broadcasterId, array $ids = [], string $bearer): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
+
+        return $this->callApi('subscriptions', $queryParamsMap, $bearer);
+    }
+}

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -75,4 +75,21 @@ class UsersApi extends AbstractResource
 
         return $this->callApi('users/follows', $queryParamsMap, $bearer);
     }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
+     */
+    public function getBroadcasterSubscriptions(string $broadcasterId, array $ids = [], string $bearer): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
+
+        return $this->callApi('subscriptions', $queryParamsMap, $bearer);
+    }
 }

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -20,17 +20,17 @@ class UsersApi extends AbstractResource
     /**
      * @throws GuzzleException
      */
-    public function getUserById(string $id, bool $includeEmail = false): ResponseInterface
+    public function getUserById(string $id, bool $includeEmail = false, string $bearer = null): ResponseInterface
     {
-        return $this->getUsers([$id], [], $includeEmail);
+        return $this->getUsers([$id], [], $includeEmail, $bearer);
     }
 
     /**
      * @throws GuzzleException
      */
-    public function getUserByUsername(string $username, bool $includeEmail = false): ResponseInterface
+    public function getUserByUsername(string $username, bool $includeEmail = false, string $bearer = null): ResponseInterface
     {
-        return $this->getUsers([], [$username], $includeEmail);
+        return $this->getUsers([], [$username], $includeEmail, $bearer);
     }
 
     /**
@@ -57,7 +57,7 @@ class UsersApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-users-follows
      */
-    public function getUsersFollows(string $followerId = null, string $followedUserId = null, int $first = null, string $after = null): ResponseInterface
+    public function getUsersFollows(string $followerId = null, string $followedUserId = null, int $first = null, string $after = null, string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
         if ($followerId) {
@@ -73,6 +73,6 @@ class UsersApi extends AbstractResource
             $queryParamsMap[] = ['key' => 'after', 'value' => $after];
         }
 
-        return $this->callApi('users/follows', $queryParamsMap);
+        return $this->callApi('users/follows', $queryParamsMap, $bearer);
     }
 }

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -75,21 +75,4 @@ class UsersApi extends AbstractResource
 
         return $this->callApi('users/follows', $queryParamsMap, $bearer);
     }
-
-    /**
-     * @throws GuzzleException
-     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
-     */
-    public function getBroadcasterSubscriptions(string $broadcasterId, array $ids = [], string $bearer): ResponseInterface
-    {
-        $queryParamsMap = [];
-
-        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
-
-        foreach ($ids as $id) {
-            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-        }
-
-        return $this->callApi('subscriptions', $queryParamsMap, $bearer);
-    }
 }


### PR DESCRIPTION
In this PR I've added optional authentication to the Users API allowing you to authenticate ultimately getting a higher rate limit to avoid hitting this cap. Additionally, I've added the Broadcaster Subscriptions API to the Users API, which is documented here: https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers