### PR TITLE
Completed SubscriptionsApi

### DIFF
--- a/src/NewTwitchApi/Resources/SubscriptionsApi.php
+++ b/src/NewTwitchApi/Resources/SubscriptionsApi.php
@@ -9,20 +9,64 @@ use Psr\Http\Message\ResponseInterface;
 
 class SubscriptionsApi extends AbstractResource
 {
-    /**
-     * @throws GuzzleException
-     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
-     */
-    public function getBroadcasterSubscriptions(string $broadcasterId, array $ids = [], string $bearer): ResponseInterface
-    {
-        $queryParamsMap = [];
 
-        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+  /**
+   * @throws GuzzleException
+   * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions
+ */
+  public function getBroadcasterSubscriptions(string $broadcasterId, string $bearer): ResponseInterface
+  {
+      $queryParamsMap = [];
 
-        foreach ($ids as $id) {
-            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-        }
+      $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-        return $this->callApi('subscriptions', $queryParamsMap, $bearer);
+      return $this->callApi('subscriptions', $queryParamsMap, $bearer);
+  }
+  /**
+   * @throws GuzzleException
+   * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
+ */
+
+  public function getBroadcasterSubscribers(string $broadcasterId, array $ids = [], string $bearer): ResponseInterface
+  {
+      $queryParamsMap = [];
+
+      $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+      foreach ($ids as $id) {
+          $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+      }
+
+      return $this->callApi('subscriptions', $queryParamsMap, $bearer);
+  }
+
+  /**
+   * @throws GuzzleException
+   * @link https://dev.twitch.tv/docs/api/reference/#get-subscription-events
+ */
+
+  public function getSubscriptionEvents(string $broadcasterId, string $eventId = null, string $userId = null, int $first = null, string $after = null, string $bearer): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+    if ($eventId) {
+        $queryParamsMap[] = ['key' => 'id', 'value' => $eventId];
     }
+
+    if ($userId) {
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+    }
+
+    if ($first) {
+        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+    }
+
+    if ($after) {
+        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    }
+
+    return $this->callApi('subscriptions/events', $queryParamsMap, $bearer);
+  }
 }


### PR DESCRIPTION
- I've updated the name of the function I passed in a previous PR to `getBroadcasterSubscribers` to match the name of the API call and to allow for the real `getBroadcasterSubscriptions` to be added 
- `getSubscriptionEvents` has been tested to ensure that the `eventId` can be `null` and that if you supply both the `broadcasterId` and `eventId`, despite the documents saying `or` - providing both will work, and the code is cleaner keeping it in one function. 