### PR TITLE
Mutliple Helix API Updates

### DIFF
--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -11,6 +11,7 @@ use NewTwitchApi\Resources\StreamsApi;
 use NewTwitchApi\Resources\UsersApi;
 use NewTwitchApi\Resources\SubscriptionsApi;
 use NewTwitchApi\Resources\VideosApi;
+use NewTwitchApi\Resources\ModerationApi;
 use NewTwitchApi\Resources\WebhooksApi;
 use NewTwitchApi\Webhooks\WebhooksSubscriptionApi;
 
@@ -22,6 +23,7 @@ class NewTwitchApi
     private $usersApi;
     private $subscriptionsApi;
     private $videosApi;
+    private $moderationApi;
     private $webhooksApi;
     private $webhooksSubscriptionApi;
 
@@ -33,6 +35,7 @@ class NewTwitchApi
         $this->usersApi = new UsersApi($helixGuzzleClient);
         $this->subscriptionsApi = new SubscriptionsApi($helixGuzzleClient);
         $this->videosApi = new VideosApi($helixGuzzleClient);
+        $this->moderationApi = new ModerationApi($helixGuzzleClient);
         $this->webhooksApi = new WebhooksApi($helixGuzzleClient);
         $this->webhooksSubscriptionApi = new WebhooksSubscriptionApi($clientId, $clientSecret, $helixGuzzleClient);
     }
@@ -65,6 +68,11 @@ class NewTwitchApi
     public function getVideosApi(): UsersApi
     {
         return $this->videosApi;
+    }
+
+    public function getModerationApi(): UsersApi
+    {
+        return $this->moderationApi;
     }
 
     public function getWebhooksApi(): WebhooksApi

--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -10,6 +10,7 @@ use NewTwitchApi\Resources\GamesApi;
 use NewTwitchApi\Resources\StreamsApi;
 use NewTwitchApi\Resources\UsersApi;
 use NewTwitchApi\Resources\SubscriptionsApi;
+use NewTwitchApi\Resources\VideosApi;
 use NewTwitchApi\Resources\WebhooksApi;
 use NewTwitchApi\Webhooks\WebhooksSubscriptionApi;
 
@@ -20,6 +21,7 @@ class NewTwitchApi
     private $streamsApi;
     private $usersApi;
     private $subscriptionsApi;
+    private $videosApi;
     private $webhooksApi;
     private $webhooksSubscriptionApi;
 
@@ -30,6 +32,7 @@ class NewTwitchApi
         $this->streamsApi = new StreamsApi($helixGuzzleClient);
         $this->usersApi = new UsersApi($helixGuzzleClient);
         $this->subscriptionsApi = new SubscriptionsApi($helixGuzzleClient);
+        $this->videosApi = new VideosApi($helixGuzzleClient);
         $this->webhooksApi = new WebhooksApi($helixGuzzleClient);
         $this->webhooksSubscriptionApi = new WebhooksSubscriptionApi($clientId, $clientSecret, $helixGuzzleClient);
     }
@@ -57,6 +60,11 @@ class NewTwitchApi
     public function getSubscriptionsApi(): UsersApi
     {
         return $this->subscriptionsApi;
+    }
+
+    public function getVideosApi(): UsersApi
+    {
+        return $this->videosApi;
     }
 
     public function getWebhooksApi(): WebhooksApi

--- a/src/NewTwitchApi/Resources/GamesApi.php
+++ b/src/NewTwitchApi/Resources/GamesApi.php
@@ -12,8 +12,8 @@ class GamesApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-games
-     */
-    public function getGames(array $ids = [], array $names = []): ResponseInterface
+   */
+    public function getGames(array $ids = [], array $names = [], string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
         foreach ($ids as $id) {
@@ -23,6 +23,29 @@ class GamesApi extends AbstractResource
             $queryParamsMap[] = ['key' => 'name', 'value' => $name];
         }
 
-        return $this->callApi('games', $queryParamsMap);
+        return $this->callApi('games', $queryParamsMap, $bearer);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-top-games
+   */
+    public function getTopGames(int $first = null, string $before = null, string $after = null, string $bearer = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($before) {
+            $queryParamsMap[] = ['key' => 'before', 'value' => $before];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('games/top', $queryParamsMap, $bearer);
     }
 }

--- a/src/NewTwitchApi/Resources/GamesApi.php
+++ b/src/NewTwitchApi/Resources/GamesApi.php
@@ -12,7 +12,7 @@ class GamesApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-games
-   */
+     */
     public function getGames(array $ids = [], array $names = [], string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -29,7 +29,7 @@ class GamesApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-top-games
-   */
+     */
     public function getTopGames(int $first = null, string $before = null, string $after = null, string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/ModerationApi.php
+++ b/src/NewTwitchApi/Resources/ModerationApi.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class ModerationApi extends AbstractResource
+{
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference/#get-banned-events
+  */
+  public function getBannedEvents(string $broadcasterId, string $bearer, array $ids = [], string $first = null, string $after = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+    foreach ($ids as $id) {
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+    }
+
+    if($first) {
+        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+    }
+
+    if($after) {
+        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    }
+
+    return $this->callApi('moderation/banned/events', $queryParamsMap, $bearer);
+  }
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference/#get-banned-users
+  */
+  public function getBannedUsers(string $broadcasterId, string $bearer, array $ids = [], string $before = null, string $after = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+    foreach ($ids as $id) {
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+    }
+
+    if($before) {
+        $queryParamsMap[] = ['key' => 'before', 'value' => $before];
+    }
+
+    if($after) {
+        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    }
+
+    return $this->callApi('moderation/banned', $queryParamsMap, $bearer);
+  }
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference/#get-moderators
+  */
+  public function getModerators(string $broadcasterId, string $bearer, array $ids = [], string $after = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+    foreach ($ids as $id) {
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+    }
+
+    if($after) {
+        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    }
+
+    return $this->callApi('moderation/moderators', $queryParamsMap, $bearer);
+  }
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference/#get-moderator-events
+  */
+  public function getModeratorEvents(string $broadcasterId, string $bearer, array $ids = [], string $after = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+    foreach ($ids as $id) {
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+    }
+
+    if($after) {
+        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    }
+
+    return $this->callApi('moderation/moderators/events', $queryParamsMap, $bearer);
+  }
+}

--- a/src/NewTwitchApi/Resources/ModerationApi.php
+++ b/src/NewTwitchApi/Resources/ModerationApi.php
@@ -11,9 +11,9 @@ class ModerationApi extends AbstractResource
 {
 
   /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference/#get-banned-events
-  */
+   * @throws GuzzleException
+   * @link https://dev.twitch.tv/docs/api/reference/#get-banned-events
+   */
   public function getBannedEvents(string $broadcasterId, string $bearer, array $ids = [], string $first = null, string $after = null): ResponseInterface
   {
     $queryParamsMap = [];
@@ -24,11 +24,11 @@ class ModerationApi extends AbstractResource
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
     }
 
-    if($first) {
+    if ($first) {
         $queryParamsMap[] = ['key' => 'first', 'value' => $first];
     }
 
-    if($after) {
+    if ($after) {
         $queryParamsMap[] = ['key' => 'after', 'value' => $after];
     }
 
@@ -36,9 +36,9 @@ class ModerationApi extends AbstractResource
   }
 
   /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference/#get-banned-users
-  */
+   * @throws GuzzleException
+   * @link https://dev.twitch.tv/docs/api/reference/#get-banned-users
+   */
   public function getBannedUsers(string $broadcasterId, string $bearer, array $ids = [], string $before = null, string $after = null): ResponseInterface
   {
     $queryParamsMap = [];
@@ -49,11 +49,11 @@ class ModerationApi extends AbstractResource
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
     }
 
-    if($before) {
+    if ($before) {
         $queryParamsMap[] = ['key' => 'before', 'value' => $before];
     }
 
-    if($after) {
+    if ($after) {
         $queryParamsMap[] = ['key' => 'after', 'value' => $after];
     }
 
@@ -74,7 +74,7 @@ class ModerationApi extends AbstractResource
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
     }
 
-    if($after) {
+    if ($after) {
         $queryParamsMap[] = ['key' => 'after', 'value' => $after];
     }
 
@@ -95,7 +95,7 @@ class ModerationApi extends AbstractResource
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
     }
 
-    if($after) {
+    if ($after) {
         $queryParamsMap[] = ['key' => 'after', 'value' => $after];
     }
 

--- a/src/NewTwitchApi/Resources/StreamsApi.php
+++ b/src/NewTwitchApi/Resources/StreamsApi.php
@@ -11,7 +11,7 @@ class StreamsApi extends AbstractResource
 {
     /**
      * @throws GuzzleException
-     */
+   */
     public function getStreamForUserId(string $userId): ResponseInterface
     {
         return $this->getStreams([$userId]);
@@ -19,7 +19,7 @@ class StreamsApi extends AbstractResource
 
     /**
      * @throws GuzzleException
-     */
+   */
     public function getStreamForUsername(string $username): ResponseInterface
     {
         return $this->getStreams([], [$username]);
@@ -28,8 +28,8 @@ class StreamsApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-streams
-     */
-    public function getStreams(array $userIds = [], array $usernames = [], array $gameIds = [], array $communityIds = [], array $languages = [], int $first = null, string $before = null, string $after = null): ResponseInterface
+   */
+    public function getStreams(array $userIds = [], array $usernames = [], array $gameIds = [], array $communityIds = [], array $languages = [], int $first = null, string $before = null, string $after = null, $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
         foreach ($userIds as $id) {
@@ -57,6 +57,72 @@ class StreamsApi extends AbstractResource
             $queryParamsMap[] = ['key' => 'after', 'value' => $after];
         }
 
-        return $this->callApi('streams', $queryParamsMap);
+        return $this->callApi('streams', $queryParamsMap, $bearer);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-streams-metadata
+   */
+    public function getStreamsMetadata(array $userIds = [], array $usernames = [], array $gameIds = [], array $communityIds = [], array $languages = [], int $first = null, string $before = null, string $after = null, string $bearer = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+        foreach ($userIds as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
+        foreach ($usernames as $username) {
+            $queryParamsMap[] = ['key' => 'user_login', 'value' => $username];
+        }
+        foreach ($gameIds as $gameId) {
+            $queryParamsMap[] = ['key' => 'game_id', 'value' => $gameId];
+        }
+        foreach ($communityIds as $communityId) {
+            $queryParamsMap[] = ['key' => 'community_id', 'value' => $communityId];
+        }
+        foreach ($languages as $language) {
+            $queryParamsMap[] = ['key' => 'language', 'value' => $language];
+        }
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+        if ($before) {
+            $queryParamsMap[] = ['key' => 'before', 'value' => $before];
+        }
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('streams/metadata', $queryParamsMap, $bearer);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-stream-markers
+   */
+    public function getStreamMarkers(string $bearer, string $userId = null, string $videoId = null, string $first = null, string $before = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        if ($userId) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        }
+
+        if ($videoId) {
+            $queryParamsMap[] = ['key' => 'video_id', 'value' => $videoId];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($before) {
+            $queryParamsMap[] = ['key' => 'before', 'value' => $before];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('streams/markers', $queryParamsMap, $bearer);
     }
 }

--- a/src/NewTwitchApi/Resources/StreamsApi.php
+++ b/src/NewTwitchApi/Resources/StreamsApi.php
@@ -11,7 +11,7 @@ class StreamsApi extends AbstractResource
 {
     /**
      * @throws GuzzleException
-   */
+     */
     public function getStreamForUserId(string $userId): ResponseInterface
     {
         return $this->getStreams([$userId]);
@@ -19,7 +19,7 @@ class StreamsApi extends AbstractResource
 
     /**
      * @throws GuzzleException
-   */
+     */
     public function getStreamForUsername(string $username): ResponseInterface
     {
         return $this->getStreams([], [$username]);
@@ -28,7 +28,7 @@ class StreamsApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-streams
-   */
+     */
     public function getStreams(array $userIds = [], array $usernames = [], array $gameIds = [], array $communityIds = [], array $languages = [], int $first = null, string $before = null, string $after = null, $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -63,7 +63,7 @@ class StreamsApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-streams-metadata
-   */
+     */
     public function getStreamsMetadata(array $userIds = [], array $usernames = [], array $gameIds = [], array $communityIds = [], array $languages = [], int $first = null, string $before = null, string $after = null, string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -98,7 +98,7 @@ class StreamsApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-stream-markers
-   */
+     */
     public function getStreamMarkers(string $bearer, string $userId = null, string $videoId = null, string $first = null, string $before = null, string $after = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/SubscriptionsApi.php
+++ b/src/NewTwitchApi/Resources/SubscriptionsApi.php
@@ -13,7 +13,7 @@ class SubscriptionsApi extends AbstractResource
   /**
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions
- */
+   */
   public function getBroadcasterSubscriptions(string $broadcasterId, string $bearer): ResponseInterface
   {
       $queryParamsMap = [];
@@ -25,7 +25,7 @@ class SubscriptionsApi extends AbstractResource
   /**
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
- */
+   */
 
   public function getBroadcasterSubscribers(string $broadcasterId, array $ids = [], string $bearer): ResponseInterface
   {
@@ -43,7 +43,7 @@ class SubscriptionsApi extends AbstractResource
   /**
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-subscription-events
- */
+   */
 
   public function getSubscriptionEvents(string $broadcasterId, string $eventId = null, string $userId = null, int $first = null, string $after = null, string $bearer): ResponseInterface
   {

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -56,7 +56,7 @@ class UsersApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-users-follows
-     */
+   */
     public function getUsersFollows(string $followerId = null, string $followedUserId = null, int $first = null, string $after = null, string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -74,5 +74,31 @@ class UsersApi extends AbstractResource
         }
 
         return $this->callApi('users/follows', $queryParamsMap, $bearer);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-user-extensions
+   */
+    public function getUserExtensions(string $bearer): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        return $this->callApi('users/extensions/list', $queryParamsMap, $bearer);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-user-active-extensions
+   */
+    public function getActiveUserExtensions(string $userId = null, string $bearer = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        if ($userId) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        }
+
+        return $this->callApi('users/extensions', $queryParamsMap, $bearer);
     }
 }

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -56,7 +56,7 @@ class UsersApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-users-follows
-   */
+     */
     public function getUsersFollows(string $followerId = null, string $followedUserId = null, int $first = null, string $after = null, string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -79,7 +79,7 @@ class UsersApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-user-extensions
-   */
+     */
     public function getUserExtensions(string $bearer): ResponseInterface
     {
         $queryParamsMap = [];
@@ -90,7 +90,7 @@ class UsersApi extends AbstractResource
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-user-active-extensions
-   */
+     */
     public function getActiveUserExtensions(string $userId = null, string $bearer = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/VideosApi.php
+++ b/src/NewTwitchApi/Resources/VideosApi.php
@@ -13,7 +13,7 @@ class VideosApi extends AbstractResource
   /**
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-videos
- */
+   */
   public function getVideos(array $ids = [], string $userId = null, string $gameId = null, string $first = null, string $before = null, string $after = null, string $language = null, string $period = null, string $sort = null, string $type = null, string $bearer = null): ResponseInterface
   {
       $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/VideosApi.php
+++ b/src/NewTwitchApi/Resources/VideosApi.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class VideosApi extends AbstractResource
+{
+
+  /**
+   * @throws GuzzleException
+   * @link https://dev.twitch.tv/docs/api/reference/#get-videos
+ */
+  public function getVideos(array $ids = [], string $userId = null, string $gameId = null, string $first = null, string $before = null, string $after = null, string $language = null, string $period = null, string $sort = null, string $type = null, string $bearer = null): ResponseInterface
+  {
+      $queryParamsMap = [];
+
+      foreach ($ids as $id) {
+          $queryParamsMap[] = ['key' => 'id', 'value' => $id];
+      }
+
+      if($userId) {
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+      }
+
+      if($gameId) {
+        $queryParamsMap[] = ['key' => 'game_id', 'value' => $gameId];
+      }
+
+      if ($first) {
+          $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+      }
+
+      if ($before) {
+          $queryParamsMap[] = ['key' => 'before', 'value' => $before];
+      }
+
+      if ($after) {
+          $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+      }
+
+      if ($language) {
+          $queryParamsMap[] = ['key' => 'language', 'value' => $language];
+      }
+
+      if ($period) {
+          $queryParamsMap[] = ['key' => 'period', 'value' => $period];
+      }
+
+      if ($sort) {
+          $queryParamsMap[] = ['key' => 'sort', 'value' => $sort];
+      }
+
+      if ($sort) {
+          $queryParamsMap[] = ['key' => 'type', 'value' => $type];
+      }
+
+      return $this->callApi('videos', $queryParamsMap, $bearer);
+  }
+}

--- a/src/NewTwitchApi/Resources/VideosApi.php
+++ b/src/NewTwitchApi/Resources/VideosApi.php
@@ -22,11 +22,11 @@ class VideosApi extends AbstractResource
           $queryParamsMap[] = ['key' => 'id', 'value' => $id];
       }
 
-      if($userId) {
+      if ($userId) {
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
       }
 
-      if($gameId) {
+      if ($gameId) {
         $queryParamsMap[] = ['key' => 'game_id', 'value' => $gameId];
       }
 


### PR DESCRIPTION
**Games**
- Added authentication support
- Added `games/top` endpoint

**Users**
- Added `users/extensions` endpoint
- Added `users/extensions/list` endpoint

**Videos**
- Added API files
- Added `videos` endpoint

**Streams**
- Added authentication to `getStreams`
- Added `streams/metadata` endpoint
- Added `streams/markers` endpoint

**Moderation**
- Added API files
- Added `moderation/banned` endpoint
- Added `moderation/banned/events` endpoint
- Added `moderation/moderators` endpoint
- Added `moderation/moderators/events` endpoint (API docs do not show an `after` parameter but it is supported, just missing from the docs

I also put together this quick Google Sheet to help keep track of the current coverage, hopefully this helps: https://bit.ly/2LYSwgp