### PR TITLE
Add subscribe to subscription events

### DIFF
--- a/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
+++ b/spec/NewTwitchApi/Webhooks/WebhooksSubscriptionApiSpec.php
@@ -41,6 +41,19 @@ class WebhooksSubscriptionApiSpec extends ObjectBehavior
         $this->subscribeToStream('12345', 'https://redirect.url', 'bearer-token', 100);
     }
 
+    function it_subscribes_to_subscription_events(Client $guzzleClient)
+    {
+        $guzzleClient->post('webhooks/hub', [
+            'headers' => [
+                'Authorization' => 'Bearer bearer-token',
+                'Client-ID' => 'client-id',
+            ],
+            'body' => '{"hub.callback":"https:\/\/redirect.url","hub.mode":"subscribe","hub.topic":"https:\/\/api.twitch.tv\/helix\/subscriptions\/events?broadcaster_id=12345&first=1","hub.lease_seconds":100,"hub.secret":"client-secret"}'
+        ])->shouldBeCalled();
+
+        $this->subscribeToSubscriptionEvents('12345', 'https://redirect.url', 'bearer-token', 100);
+    }
+
     function it_subscribes_to_a_user(Client $guzzleClient)
     {
         $guzzleClient->post('webhooks/hub', [

--- a/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
+++ b/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
@@ -33,6 +33,16 @@ class WebhooksSubscriptionApi
         );
     }
 
+    public function subscribeToSubscriptionEvents(string $twitchId, string $callback, string $bearer, int $leaseSeconds = 0): void
+    {
+        $this->subscribe(
+            sprintf('https://api.twitch.tv/helix/subscriptions/events?broadcaster_id=%s&first=1', $twitchId),
+            $callback,
+            $bearer,
+            $leaseSeconds
+        );
+    }
+
     public function subscribeToUser(string $twitchId, string $callback, string $bearer = null, int $leaseSeconds = 0): void
     {
         $this->subscribe(


### PR DESCRIPTION
### Proposed Change
- Add method to subscribe to the [Topic: Subscription Events](https://dev.twitch.tv/docs/api/webhooks-reference/#topic-subscription-events) webhook
- Add spec for the new method