### PR TITLE
Return correct API types

### DIFF
--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -60,17 +60,17 @@ class NewTwitchApi
         return $this->usersApi;
     }
 
-    public function getSubscriptionsApi(): UsersApi
+    public function getSubscriptionsApi(): SubscriptionsApi
     {
         return $this->subscriptionsApi;
     }
 
-    public function getVideosApi(): UsersApi
+    public function getVideosApi(): VideosApi
     {
         return $this->videosApi;
     }
 
-    public function getModerationApi(): UsersApi
+    public function getModerationApi(): ModerationApi
     {
         return $this->moderationApi;
     }


### PR DESCRIPTION
These three APIs should probably return the proper classes and not `UsersApi`.