### PR TITLE
Fix getBroadcasterSubscriptions optional params

### DIFF
--- a/src/NewTwitchApi/Resources/SubscriptionsApi.php
+++ b/src/NewTwitchApi/Resources/SubscriptionsApi.php
@@ -14,11 +14,19 @@ class SubscriptionsApi extends AbstractResource
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions
    */
-  public function getBroadcasterSubscriptions(string $broadcasterId, string $bearer): ResponseInterface
+  public function getBroadcasterSubscriptions(string $broadcasterId, int $first = null, string $after = null, string $bearer): ResponseInterface
   {
       $queryParamsMap = [];
 
       $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+      if ($first) {
+          $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+      }
+
+      if ($after) {
+          $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+      }
 
       return $this->callApi('subscriptions', $queryParamsMap, $bearer);
   }


### PR DESCRIPTION
The docs for [Get Broadcaster Subscriptions](https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions) are incomplete and missing the `first` and `after` optional parameters.

-  **First** is needed to set limit of items in the response payload (default is 25, max can be set to 100). 
-  **After** sets the cursor for pagination. 

Both function similarly to other calls like [Get Subscription Events](https://dev.twitch.tv/docs/api/reference/#get-subscription-events)