### PR TITLE
Added numerous missing and new Endpoints to the NewTwitchApi

### DIFF
--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -57,7 +57,7 @@ class NewTwitchApi
         return $this->oauthApi;
     }
 
-    public function getBitsApi(): ClipsApi
+    public function getBitsApi(): BitsApi
     {
         return $this->bitsApi;
     }
@@ -72,7 +72,7 @@ class NewTwitchApi
         return $this->gamesApi;
     }
 
-    public function getHypeTrainApi(): GamesApi
+    public function getHypeTrainApi(): HypeTrainApi
     {
         return $this->hypeTrainApi;
     }
@@ -82,7 +82,7 @@ class NewTwitchApi
         return $this->moderationApi;
     }
 
-    public function getSearchApi(): StreamsApi
+    public function getSearchApi(): SearchApi
     {
         return $this->searchApi;
     }

--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -6,39 +6,48 @@ namespace NewTwitchApi;
 
 use GuzzleHttp\Client;
 use NewTwitchApi\Auth\OauthApi;
+use NewTwitchApi\Resources\BitsApi;
 use NewTwitchApi\Resources\ClipsApi;
 use NewTwitchApi\Resources\GamesApi;
-use NewTwitchApi\Resources\StreamsApi;
-use NewTwitchApi\Resources\UsersApi;
-use NewTwitchApi\Resources\SubscriptionsApi;
-use NewTwitchApi\Resources\VideosApi;
+use NewTwitchApi\Resources\HypeTrainApi;
 use NewTwitchApi\Resources\ModerationApi;
+use NewTwitchApi\Resources\SearchApi;
+use NewTwitchApi\Resources\StreamsApi;
+use NewTwitchApi\Resources\SubscriptionsApi;
+use NewTwitchApi\Resources\UsersApi;
+use NewTwitchApi\Resources\VideosApi;
 use NewTwitchApi\Resources\WebhooksApi;
 use NewTwitchApi\Webhooks\WebhooksSubscriptionApi;
 
 class NewTwitchApi
 {
     private $oauthApi;
+    private $bitsApi;
     private $clipsApi;
     private $gamesApi;
-    private $streamsApi;
-    private $usersApi;
-    private $subscriptionsApi;
-    private $videosApi;
+    private $hypeTrainApi;
     private $moderationApi;
+    private $searchApi;
+    private $streamsApi;
+    private $subscriptionsApi;
+    private $usersApi;
+    private $videosApi;
     private $webhooksApi;
     private $webhooksSubscriptionApi;
 
     public function __construct(Client $helixGuzzleClient, string $clientId, string $clientSecret, Client $authGuzzleClient = null)
     {
         $this->oauthApi = new OauthApi($clientId, $clientSecret, $authGuzzleClient);
+        $this->bitsApi = new BitsApi($helixGuzzleClient);
         $this->clipsApi = new ClipsApi($helixGuzzleClient);
         $this->gamesApi = new GamesApi($helixGuzzleClient);
-        $this->streamsApi = new StreamsApi($helixGuzzleClient);
-        $this->usersApi = new UsersApi($helixGuzzleClient);
-        $this->subscriptionsApi = new SubscriptionsApi($helixGuzzleClient);
-        $this->videosApi = new VideosApi($helixGuzzleClient);
+        $this->hypeTrainApi = new HypeTrainApi($helixGuzzleClient);
         $this->moderationApi = new ModerationApi($helixGuzzleClient);
+        $this->searchApi = new SearchApi($helixGuzzleClient);
+        $this->streamsApi = new StreamsApi($helixGuzzleClient);
+        $this->subscriptionsApi = new SubscriptionsApi($helixGuzzleClient);
+        $this->usersApi = new UsersApi($helixGuzzleClient);
+        $this->videosApi = new VideosApi($helixGuzzleClient);
         $this->webhooksApi = new WebhooksApi($helixGuzzleClient);
         $this->webhooksSubscriptionApi = new WebhooksSubscriptionApi($clientId, $clientSecret, $helixGuzzleClient);
     }
@@ -46,6 +55,11 @@ class NewTwitchApi
     public function getOauthApi(): OauthApi
     {
         return $this->oauthApi;
+    }
+
+    public function getBitsApi(): ClipsApi
+    {
+        return $this->bitsApi;
     }
 
     public function getClipsApi(): ClipsApi
@@ -58,14 +72,24 @@ class NewTwitchApi
         return $this->gamesApi;
     }
 
+    public function getHypeTrainApi(): GamesApi
+    {
+        return $this->hypeTrainApi;
+    }
+
+    public function getModerationApi(): ModerationApi
+    {
+        return $this->moderationApi;
+    }
+
+    public function getSearchApi(): StreamsApi
+    {
+        return $this->searchApi;
+    }
+
     public function getStreamsApi(): StreamsApi
     {
         return $this->streamsApi;
-    }
-
-    public function getUsersApi(): UsersApi
-    {
-        return $this->usersApi;
     }
 
     public function getSubscriptionsApi(): SubscriptionsApi
@@ -73,14 +97,14 @@ class NewTwitchApi
         return $this->subscriptionsApi;
     }
 
+    public function getUsersApi(): UsersApi
+    {
+        return $this->usersApi;
+    }
+
     public function getVideosApi(): VideosApi
     {
         return $this->videosApi;
-    }
-
-    public function getModerationApi(): ModerationApi
-    {
-        return $this->moderationApi;
     }
 
     public function getWebhooksApi(): WebhooksApi

--- a/src/NewTwitchApi/Resources/BitsApi.php
+++ b/src/NewTwitchApi/Resources/BitsApi.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class BitsApi extends AbstractResource
+{
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference#get-cheermotes
+  */
+  public function getCheermotes(string $bearer, string $broadcasterId = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    if ($broadcasterId) {
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+    }
+
+    return $this->callApi('bits/cheermotes', $bearer, $queryParamsMap);
+  }
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference#get-bits-leaderboard
+  */
+  public function getBitsLeaderboard(string $bearer, int $count = null, string $period = null, string $startedAt = null, string $userId = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    if ($count) {
+        $queryParamsMap[] = ['key' => 'count', 'value' => $count];
+    }
+
+    if ($period) {
+        $queryParamsMap[] = ['key' => 'period', 'value' => $period];
+    }
+
+    if ($startedAt) {
+        $queryParamsMap[] = ['key' => 'started_at', 'value' => $startedAt];
+    }
+
+    if ($userId) {
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+    }
+
+    return $this->callApi('bits/leaderboard', $bearer, $queryParamsMap);
+  }
+}

--- a/src/NewTwitchApi/Resources/HypeTrainApi.php
+++ b/src/NewTwitchApi/Resources/HypeTrainApi.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class HypeTrainApi extends AbstractResource
+{
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference#get-hype-train-events
+  */
+  public function getHypeTrainEvents(string $bearer, string $broadcasterId, int $first = null, string $id = null, string $cursor = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $first];
+
+    if ($first) {
+        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+    }
+
+    if ($id) {
+        $queryParamsMap[] = ['key' => 'id', 'value' => $id];
+    }
+
+    if ($cursor) {
+        $queryParamsMap[] = ['key' => 'cursor', 'value' => $cursor];
+    }
+
+    return $this->callApi('bits/cheermotes', $bearer, $queryParamsMap);
+  }
+}

--- a/src/NewTwitchApi/Resources/SearchApi.php
+++ b/src/NewTwitchApi/Resources/SearchApi.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class SearchApi extends AbstractResource
+{
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference#search-categories
+  */
+  public function searchCategories(string $bearer, string $query, string $first = null, string $after = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'query', 'value' => $query];
+
+    if ($first) {
+        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+    }
+
+    if ($after) {
+        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    }
+
+    return $this->callApi('serach/categories', $bearer, $queryParamsMap);
+  }
+
+  /**
+  * @throws GuzzleException
+  * @link https://dev.twitch.tv/docs/api/reference#search-channels
+  */
+  public function searchChannels(string $bearer, string $query, $liveOnly = null, string $first = null, string $after = null): ResponseInterface
+  {
+    $queryParamsMap = [];
+
+    $queryParamsMap[] = ['key' => 'query', 'value' => $query];
+
+    if ($liveOnly) {
+        $queryParamsMap[] = ['key' => 'live_only', 'value' => $liveOnly];
+    }
+
+    if ($first) {
+        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+    }
+
+    if ($after) {
+        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    }
+
+    return $this->callApi('serach/categories', $bearer, $queryParamsMap);
+  }
+}

--- a/src/NewTwitchApi/Resources/StreamsApi.php
+++ b/src/NewTwitchApi/Resources/StreamsApi.php
@@ -27,6 +27,19 @@ class StreamsApi extends AbstractResource
 
     /**
      * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-stream-key
+     */
+    public function getStreamKey(string $bearer, string $broadcasterId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        return $this->callApi('streams/key', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-streams
      */
     public function getStreams(string $bearer, array $userIds = [], array $usernames = [], array $gameIds = [], array $communityIds = [], array $languages = [], int $first = null, string $before = null, string $after = null): ResponseInterface
@@ -124,5 +137,20 @@ class StreamsApi extends AbstractResource
         }
 
         return $this->callApi('streams/markers', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-channel-information
+     */
+    public function getChannelInfo(string $bearer, array $broadcasterIds): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        foreach ($broadcasterIds as $id) {
+            $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $id];
+        }
+
+        return $this->callApi('channels', $bearer, $queryParamsMap);
     }
 }


### PR DESCRIPTION
- Normalized order of Resources to be Alphabetical (Twitch's Documentation is becoming out of order, we need to establish our own sorting now)
- Added NewTwitchApi->getBitsApi
- Added BitsApi->getCheermotes
- Added BitsApi->getBitsLeaderboard
- Added NewTwitchApi->getHypeTrainApi
- Added HypeTrainApi->getHypeTrainEvents
- Added NewTwitchApi->getSearchApi
- Added SearchApi->searchCategories
- Added SerachApi->searchChannels
- Added StreamsApi->getChannelInfo
- Added StreamsApi->getStreamKey