### PR TITLE
CS Clean up and other fixes

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -2,6 +2,7 @@
 
 $finder = PhpCsFixer\Finder::create()
     ->in('src/NewTwitchApi/')
+    ->in('test/NewTwitchApi/')
 ;
 
 return PhpCsFixer\Config::create()

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "autoload": {
         "psr-4": {
             "TwitchApi\\": "src/",
-            "NewTwitchApi\\": "src/NewTwitchApi"
+            "NewTwitchApi\\": "src/NewTwitchApi",
+            "NewTwitchApi\\Tests\\": "test/NewTwitchApi"
         }
     },
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0c33e6d68039bb8af47a8d90cacb2b8",
+    "content-hash": "ea9f8539be86ecfc29d8229a3266a8c5",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.4",
+            "version": "6.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "a4a1b6930528a8f7ee03518e6442ec7a44155d9d"
+                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a4a1b6930528a8f7ee03518e6442ec7a44155d9d",
-                "reference": "a4a1b6930528a8f7ee03518e6442ec7a44155d9d",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,7 @@
                 "guzzlehttp/promises": "^1.0",
                 "guzzlehttp/psr7": "^1.6.1",
                 "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "1.17.0"
+                "symfony/polyfill-intl-idn": "^1.17.0"
             },
             "require-dev": {
                 "ext-curl": "*",
@@ -71,7 +71,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2020-05-25T19:35:05+00:00"
+            "time": "2020-06-16T21:01:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1280,16 +1280,16 @@
         },
         {
             "name": "phpspec/phpspec",
-            "version": "6.1.1",
+            "version": "6.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/phpspec.git",
-                "reference": "486aaa736e9e24f3e22a6545f6affb88f98e2602"
+                "reference": "763c4e3abbf590ef8009effd295b71aed11dd595"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/486aaa736e9e24f3e22a6545f6affb88f98e2602",
-                "reference": "486aaa736e9e24f3e22a6545f6affb88f98e2602",
+                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/763c4e3abbf590ef8009effd295b71aed11dd595",
+                "reference": "763c4e3abbf590ef8009effd295b71aed11dd595",
                 "shasum": ""
             },
             "require": {
@@ -1298,7 +1298,7 @@
                 "php": "^7.2, <7.5",
                 "phpspec/php-diff": "^1.0.0",
                 "phpspec/prophecy": "^1.9",
-                "sebastian/exporter": "^1.0 || ^2.0 || ^3.0",
+                "sebastian/exporter": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "symfony/console": "^3.4 || ^4.0 || ^5.0",
                 "symfony/event-dispatcher": "^3.4 || ^4.0 || ^5.0",
                 "symfony/finder": "^3.4 || ^4.0 || ^5.0",
@@ -1322,7 +1322,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1.x-dev"
+                    "dev-master": "6.2.x-dev"
                 }
             },
             "autoload": {
@@ -1360,7 +1360,7 @@
                 "testing",
                 "tests"
             ],
-            "time": "2019-12-17T10:23:12+00:00"
+            "time": "2020-06-16T20:05:07+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1679,16 +1679,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.5",
+            "version": "8.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "63dda3b212a0025d380a745f91bdb4d8c985adb7"
+                "reference": "3f9c4079d1407cd84c51c02c6ad1df6ec2ed1348"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/63dda3b212a0025d380a745f91bdb4d8c985adb7",
-                "reference": "63dda3b212a0025d380a745f91bdb4d8c985adb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3f9c4079d1407cd84c51c02c6ad1df6ec2ed1348",
+                "reference": "3f9c4079d1407cd84c51c02c6ad1df6ec2ed1348",
                 "shasum": ""
             },
             "require": {
@@ -1758,7 +1758,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-05-22T13:51:52+00:00"
+            "time": "2020-06-15T10:45:47+00:00"
         },
         {
             "name": "psr/container",
@@ -2519,16 +2519,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "00bed125812716d09b163f0727ef33bb49bf3448"
+                "reference": "34ac555a3627e324b660e318daa07572e1140123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/00bed125812716d09b163f0727ef33bb49bf3448",
-                "reference": "00bed125812716d09b163f0727ef33bb49bf3448",
+                "url": "https://api.github.com/repos/symfony/console/zipball/34ac555a3627e324b660e318daa07572e1140123",
+                "reference": "34ac555a3627e324b660e318daa07572e1140123",
                 "shasum": ""
             },
             "require": {
@@ -2594,7 +2594,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-05-30T20:35:19+00:00"
+            "time": "2020-06-15T12:59:21+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2644,7 +2644,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -2774,7 +2774,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -2824,7 +2824,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2873,7 +2873,7 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -3289,7 +3289,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -3397,7 +3397,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -3447,16 +3447,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "90c2a5103f07feb19069379f3abdcdbacc7753a9"
+                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/90c2a5103f07feb19069379f3abdcdbacc7753a9",
-                "reference": "90c2a5103f07feb19069379f3abdcdbacc7753a9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ac70459db781108db7c6d8981dd31ce0e29e3298",
+                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298",
                 "shasum": ""
             },
             "require": {
@@ -3514,11 +3514,11 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-06-11T12:16:36+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.1.0",
+            "version": "v5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -3621,16 +3621,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
                 "shasum": ""
             },
             "require": {
@@ -3638,6 +3638,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
+                "phpstan/phpstan": "<0.12.20",
                 "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
@@ -3665,7 +3666,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-04-18T12:12:48+00:00"
+            "time": "2020-06-16T10:16:42+00:00"
         }
     ],
     "aliases": [],
@@ -3674,7 +3675,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "ext-json": "*"
     },
     "platform-dev": []

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit bootstrap="vendor/autoload.php"
          colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>

--- a/src/NewTwitchApi/Resources/BitsApi.php
+++ b/src/NewTwitchApi/Resources/BitsApi.php
@@ -14,41 +14,41 @@ class BitsApi extends AbstractResource
   * @throws GuzzleException
   * @link https://dev.twitch.tv/docs/api/reference#get-cheermotes
   */
-  public function getCheermotes(string $bearer, string $broadcasterId = null): ResponseInterface
-  {
-    $queryParamsMap = [];
+    public function getCheermotes(string $bearer, string $broadcasterId = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-    if ($broadcasterId) {
-        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        if ($broadcasterId) {
+            $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        }
+
+        return $this->callApi('bits/cheermotes', $bearer, $queryParamsMap);
     }
 
-    return $this->callApi('bits/cheermotes', $bearer, $queryParamsMap);
-  }
+    /**
+    * @throws GuzzleException
+    * @link https://dev.twitch.tv/docs/api/reference#get-bits-leaderboard
+    */
+    public function getBitsLeaderboard(string $bearer, int $count = null, string $period = null, string $startedAt = null, string $userId = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-  /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference#get-bits-leaderboard
-  */
-  public function getBitsLeaderboard(string $bearer, int $count = null, string $period = null, string $startedAt = null, string $userId = null): ResponseInterface
-  {
-    $queryParamsMap = [];
+        if ($count) {
+            $queryParamsMap[] = ['key' => 'count', 'value' => $count];
+        }
 
-    if ($count) {
-        $queryParamsMap[] = ['key' => 'count', 'value' => $count];
+        if ($period) {
+            $queryParamsMap[] = ['key' => 'period', 'value' => $period];
+        }
+
+        if ($startedAt) {
+            $queryParamsMap[] = ['key' => 'started_at', 'value' => $startedAt];
+        }
+
+        if ($userId) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        }
+
+        return $this->callApi('bits/leaderboard', $bearer, $queryParamsMap);
     }
-
-    if ($period) {
-        $queryParamsMap[] = ['key' => 'period', 'value' => $period];
-    }
-
-    if ($startedAt) {
-        $queryParamsMap[] = ['key' => 'started_at', 'value' => $startedAt];
-    }
-
-    if ($userId) {
-        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
-    }
-
-    return $this->callApi('bits/leaderboard', $bearer, $queryParamsMap);
-  }
 }

--- a/src/NewTwitchApi/Resources/ClipsApi.php
+++ b/src/NewTwitchApi/Resources/ClipsApi.php
@@ -14,7 +14,7 @@ class ClipsApi extends AbstractResource
      */
     public function getClipsByBroadcasterId(string $bearer, string $broadcasterId, int $first = null, string $before = null, string $after = null, string $startedAt = null, string $endedAt = null): ResponseInterface
     {
-        return $this->getClips($bearer, $broadcasterId, NULL, NULL, $first, $before, $after, $startedAt, $endedAt);
+        return $this->getClips($bearer, $broadcasterId, null, null, $first, $before, $after, $startedAt, $endedAt);
     }
 
     /**
@@ -22,7 +22,7 @@ class ClipsApi extends AbstractResource
      */
     public function getClipsByGameId(string $bearer, string $gameId, int $first = null, string $before = null, string $after = null, string $startedAt = null, string $endedAt = null): ResponseInterface
     {
-        return $this->getClips($bearer, NULL, $gameId, NULL, $first, $before, $after, $startedAt, $endedAt);
+        return $this->getClips($bearer, null, $gameId, null, $first, $before, $after, $startedAt, $endedAt);
     }
 
     /**
@@ -30,7 +30,7 @@ class ClipsApi extends AbstractResource
      */
     public function getClipsByIds(string $bearer, string $clipIds, string $startedAt = null, string $endedAt = null): ResponseInterface
     {
-        return $this->getClips($bearer, NULL, NULL, $clipIds, NULL, NULL, NULL, $startedAt, $endedAt);
+        return $this->getClips($bearer, null, null, $clipIds, null, null, null, $startedAt, $endedAt);
     }
 
     /**

--- a/src/NewTwitchApi/Resources/HypeTrainApi.php
+++ b/src/NewTwitchApi/Resources/HypeTrainApi.php
@@ -14,24 +14,24 @@ class HypeTrainApi extends AbstractResource
   * @throws GuzzleException
   * @link https://dev.twitch.tv/docs/api/reference#get-hype-train-events
   */
-  public function getHypeTrainEvents(string $bearer, string $broadcasterId, int $first = null, string $id = null, string $cursor = null): ResponseInterface
-  {
-    $queryParamsMap = [];
+    public function getHypeTrainEvents(string $bearer, string $broadcasterId, int $first = null, string $id = null, string $cursor = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $first];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-    if ($first) {
-        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($id) {
+            $queryParamsMap[] = ['key' => 'id', 'value' => $id];
+        }
+
+        if ($cursor) {
+            $queryParamsMap[] = ['key' => 'cursor', 'value' => $cursor];
+        }
+
+        return $this->callApi('bits/cheermotes', $bearer, $queryParamsMap);
     }
-
-    if ($id) {
-        $queryParamsMap[] = ['key' => 'id', 'value' => $id];
-    }
-
-    if ($cursor) {
-        $queryParamsMap[] = ['key' => 'cursor', 'value' => $cursor];
-    }
-
-    return $this->callApi('bits/cheermotes', $bearer, $queryParamsMap);
-  }
 }

--- a/src/NewTwitchApi/Resources/ModerationApi.php
+++ b/src/NewTwitchApi/Resources/ModerationApi.php
@@ -14,91 +14,91 @@ class ModerationApi extends AbstractResource
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-banned-events
    */
-  public function getBannedEvents(string $bearer, string $broadcasterId, array $ids = [], string $first = null, string $after = null): ResponseInterface
-  {
-    $queryParamsMap = [];
+    public function getBannedEvents(string $bearer, string $broadcasterId, array $ids = [], string $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-    foreach ($ids as $id) {
-        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('moderation/banned/events', $bearer, $queryParamsMap);
     }
 
-    if ($first) {
-        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-banned-users
+     */
+    public function getBannedUsers(string $bearer, string $broadcasterId, array $ids = [], string $before = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
+
+        if ($before) {
+            $queryParamsMap[] = ['key' => 'before', 'value' => $before];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('moderation/banned', $bearer, $queryParamsMap);
     }
 
-    if ($after) {
-        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    /**
+    * @throws GuzzleException
+    * @link https://dev.twitch.tv/docs/api/reference/#get-moderators
+    */
+    public function getModerators(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('moderation/moderators', $bearer, $queryParamsMap);
     }
 
-    return $this->callApi('moderation/banned/events', $bearer, $queryParamsMap);
-  }
+    /**
+    * @throws GuzzleException
+    * @link https://dev.twitch.tv/docs/api/reference/#get-moderator-events
+    */
+    public function getModeratorEvents(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-  /**
-   * @throws GuzzleException
-   * @link https://dev.twitch.tv/docs/api/reference/#get-banned-users
-   */
-  public function getBannedUsers(string $bearer, string $broadcasterId, array $ids = [], string $before = null, string $after = null): ResponseInterface
-  {
-    $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
 
-    foreach ($ids as $id) {
-        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('moderation/moderators/events', $bearer, $queryParamsMap);
     }
-
-    if ($before) {
-        $queryParamsMap[] = ['key' => 'before', 'value' => $before];
-    }
-
-    if ($after) {
-        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-    }
-
-    return $this->callApi('moderation/banned', $bearer, $queryParamsMap);
-  }
-
-  /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference/#get-moderators
-  */
-  public function getModerators(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
-  {
-    $queryParamsMap = [];
-
-    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
-
-    foreach ($ids as $id) {
-        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-    }
-
-    if ($after) {
-        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-    }
-
-    return $this->callApi('moderation/moderators', $bearer, $queryParamsMap);
-  }
-
-  /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference/#get-moderator-events
-  */
-  public function getModeratorEvents(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
-  {
-    $queryParamsMap = [];
-
-    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
-
-    foreach ($ids as $id) {
-        $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-    }
-
-    if ($after) {
-        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-    }
-
-    return $this->callApi('moderation/moderators/events', $bearer, $queryParamsMap);
-  }
 }

--- a/src/NewTwitchApi/Resources/SearchApi.php
+++ b/src/NewTwitchApi/Resources/SearchApi.php
@@ -14,45 +14,45 @@ class SearchApi extends AbstractResource
   * @throws GuzzleException
   * @link https://dev.twitch.tv/docs/api/reference#search-categories
   */
-  public function searchCategories(string $bearer, string $query, string $first = null, string $after = null): ResponseInterface
-  {
-    $queryParamsMap = [];
+    public function searchCategories(string $bearer, string $query, string $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-    $queryParamsMap[] = ['key' => 'query', 'value' => $query];
+        $queryParamsMap[] = ['key' => 'query', 'value' => $query];
 
-    if ($first) {
-        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('serach/categories', $bearer, $queryParamsMap);
     }
 
-    if ($after) {
-        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+    /**
+    * @throws GuzzleException
+    * @link https://dev.twitch.tv/docs/api/reference#search-channels
+    */
+    public function searchChannels(string $bearer, string $query, $liveOnly = null, string $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'query', 'value' => $query];
+
+        if ($liveOnly) {
+            $queryParamsMap[] = ['key' => 'live_only', 'value' => $liveOnly];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('serach/categories', $bearer, $queryParamsMap);
     }
-
-    return $this->callApi('serach/categories', $bearer, $queryParamsMap);
-  }
-
-  /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference#search-channels
-  */
-  public function searchChannels(string $bearer, string $query, $liveOnly = null, string $first = null, string $after = null): ResponseInterface
-  {
-    $queryParamsMap = [];
-
-    $queryParamsMap[] = ['key' => 'query', 'value' => $query];
-
-    if ($liveOnly) {
-        $queryParamsMap[] = ['key' => 'live_only', 'value' => $liveOnly];
-    }
-
-    if ($first) {
-        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-    }
-
-    if ($after) {
-        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-    }
-
-    return $this->callApi('serach/categories', $bearer, $queryParamsMap);
-  }
 }

--- a/src/NewTwitchApi/Resources/SubscriptionsApi.php
+++ b/src/NewTwitchApi/Resources/SubscriptionsApi.php
@@ -14,67 +14,67 @@ class SubscriptionsApi extends AbstractResource
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions
    */
-  public function getBroadcasterSubscriptions(string $bearer, string $broadcasterId, int $first = null, string $after = null): ResponseInterface
-  {
-      $queryParamsMap = [];
+    public function getBroadcasterSubscriptions(string $bearer, string $broadcasterId, int $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-      $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-      if ($first) {
-          $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-      }
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
 
-      if ($after) {
-          $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-      }
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
 
-      return $this->callApi('subscriptions', $bearer, $queryParamsMap);
-  }
-  /**
-   * @throws GuzzleException
-   * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
-   */
+        return $this->callApi('subscriptions', $bearer, $queryParamsMap);
+    }
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
+     */
 
-  public function getBroadcasterSubscribers(string $bearer, string $broadcasterId, array $ids = []): ResponseInterface
-  {
-      $queryParamsMap = [];
+    public function getBroadcasterSubscribers(string $bearer, string $broadcasterId, array $ids = []): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-      $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-      foreach ($ids as $id) {
-          $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-      }
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
+        }
 
-      return $this->callApi('subscriptions', $bearer, $queryParamsMap);
-  }
-
-  /**
-   * @throws GuzzleException
-   * @link https://dev.twitch.tv/docs/api/reference/#get-subscription-events
-   */
-
-  public function getSubscriptionEvents(string $bearer, string $broadcasterId, string $eventId = null, string $userId = null, int $first = null, string $after = null): ResponseInterface
-  {
-    $queryParamsMap = [];
-
-    $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
-
-    if ($eventId) {
-        $queryParamsMap[] = ['key' => 'id', 'value' => $eventId];
+        return $this->callApi('subscriptions', $bearer, $queryParamsMap);
     }
 
-    if ($userId) {
-        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
-    }
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-subscription-events
+     */
 
-    if ($first) {
-        $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-    }
+    public function getSubscriptionEvents(string $bearer, string $broadcasterId, string $eventId = null, string $userId = null, int $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-    if ($after) {
-        $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-    }
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-    return $this->callApi('subscriptions/events', $bearer, $queryParamsMap);
-  }
+        if ($eventId) {
+            $queryParamsMap[] = ['key' => 'id', 'value' => $eventId];
+        }
+
+        if ($userId) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->callApi('subscriptions/events', $bearer, $queryParamsMap);
+    }
 }

--- a/src/NewTwitchApi/Resources/VideosApi.php
+++ b/src/NewTwitchApi/Resources/VideosApi.php
@@ -14,50 +14,50 @@ class VideosApi extends AbstractResource
    * @throws GuzzleException
    * @link https://dev.twitch.tv/docs/api/reference/#get-videos
    */
-  public function getVideos(string $bearer, array $ids = [], string $userId = null, string $gameId = null, string $first = null, string $before = null, string $after = null, string $language = null, string $period = null, string $sort = null, string $type = null): ResponseInterface
-  {
-      $queryParamsMap = [];
+    public function getVideos(string $bearer, array $ids = [], string $userId = null, string $gameId = null, string $first = null, string $before = null, string $after = null, string $language = null, string $period = null, string $sort = null, string $type = null): ResponseInterface
+    {
+        $queryParamsMap = [];
 
-      foreach ($ids as $id) {
-          $queryParamsMap[] = ['key' => 'id', 'value' => $id];
-      }
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'id', 'value' => $id];
+        }
 
-      if ($userId) {
-        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
-      }
+        if ($userId) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        }
 
-      if ($gameId) {
-        $queryParamsMap[] = ['key' => 'game_id', 'value' => $gameId];
-      }
+        if ($gameId) {
+            $queryParamsMap[] = ['key' => 'game_id', 'value' => $gameId];
+        }
 
-      if ($first) {
-          $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-      }
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
 
-      if ($before) {
-          $queryParamsMap[] = ['key' => 'before', 'value' => $before];
-      }
+        if ($before) {
+            $queryParamsMap[] = ['key' => 'before', 'value' => $before];
+        }
 
-      if ($after) {
-          $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-      }
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
 
-      if ($language) {
-          $queryParamsMap[] = ['key' => 'language', 'value' => $language];
-      }
+        if ($language) {
+            $queryParamsMap[] = ['key' => 'language', 'value' => $language];
+        }
 
-      if ($period) {
-          $queryParamsMap[] = ['key' => 'period', 'value' => $period];
-      }
+        if ($period) {
+            $queryParamsMap[] = ['key' => 'period', 'value' => $period];
+        }
 
-      if ($sort) {
-          $queryParamsMap[] = ['key' => 'sort', 'value' => $sort];
-      }
+        if ($sort) {
+            $queryParamsMap[] = ['key' => 'sort', 'value' => $sort];
+        }
 
-      if ($sort) {
-          $queryParamsMap[] = ['key' => 'type', 'value' => $type];
-      }
+        if ($sort) {
+            $queryParamsMap[] = ['key' => 'type', 'value' => $type];
+        }
 
-      return $this->callApi('videos', $bearer, $queryParamsMap);
-  }
+        return $this->callApi('videos', $bearer, $queryParamsMap);
+    }
 }

--- a/test/NewTwitchApi/Resources/UsersTest.php
+++ b/test/NewTwitchApi/Resources/UsersTest.php
@@ -10,25 +10,14 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use NewTwitchApi\Resources\UsersApi;
 use PHPUnit\Framework\TestCase;
-use NewTwitchApi\Auth\OauthApi;
 
 class UsersTest extends TestCase
 {
-
-    private function getAppAccessToken()
-    {
-        $oauth = new OauthApi('CLIENT_ID','CLIENT_SECRET');
-        $oauth = $oauth->getAppAccessToken();
-        $responseContent = json_decode($oauth->getBody()->getContents());
-        return $responseContent->access_token;
-    }
-
     public function testGetUserByIdShouldReturnSuccessfulResponseWithUserData(): void
     {
-
         $appAccessToken = "TEST_APP_ACCESS_TOKEN";
         $users = new UsersApi($this->getGuzzleClientWithMockUserResponse());
-        $response = $users->getUserById($appAccessToken,'44322889');
+        $response = $users->getUserById($appAccessToken, '44322889');
 
         $this->assertEquals(200, $response->getStatusCode());
         $contents = json_decode($response->getBody()->getContents());
@@ -37,10 +26,9 @@ class UsersTest extends TestCase
 
     public function testGetUserByUsernameShouldReturnSuccessfulResponseWithUserData(): void
     {
-
         $appAccessToken = "TEST_APP_ACCESS_TOKEN";
         $users = new UsersApi($this->getGuzzleClientWithMockUserResponse());
-        $response = $users->getUserByUsername($appAccessToken,'dallas');
+        $response = $users->getUserByUsername($appAccessToken, 'dallas');
 
         $this->assertEquals(200, $response->getStatusCode());
         $contents = json_decode($response->getBody()->getContents());

--- a/test/NewTwitchApi/Resources/UsersTest.php
+++ b/test/NewTwitchApi/Resources/UsersTest.php
@@ -15,9 +15,8 @@ class UsersTest extends TestCase
 {
     public function testGetUserByIdShouldReturnSuccessfulResponseWithUserData(): void
     {
-        $appAccessToken = "TEST_APP_ACCESS_TOKEN";
         $users = new UsersApi($this->getGuzzleClientWithMockUserResponse());
-        $response = $users->getUserById($appAccessToken, '44322889');
+        $response = $users->getUserById('TEST_APP_ACCESS_TOKEN', '44322889');
 
         $this->assertEquals(200, $response->getStatusCode());
         $contents = json_decode($response->getBody()->getContents());
@@ -26,9 +25,8 @@ class UsersTest extends TestCase
 
     public function testGetUserByUsernameShouldReturnSuccessfulResponseWithUserData(): void
     {
-        $appAccessToken = "TEST_APP_ACCESS_TOKEN";
         $users = new UsersApi($this->getGuzzleClientWithMockUserResponse());
-        $response = $users->getUserByUsername($appAccessToken, 'dallas');
+        $response = $users->getUserByUsername('TEST_APP_ACCESS_TOKEN', 'dallas');
 
         $this->assertEquals(200, $response->getStatusCode());
         $contents = json_decode($response->getBody()->getContents());


### PR DESCRIPTION
This PR includes:

- **IMPORTANT** Fixed `HypeTrainAPI::getHypeTrainEvents()` use of `$broadcasterId` (FYI @brandinarsenault)
- `php-cs-fixer` fixes for all NewTwitchApi code (especially the newest code added by @brandinarsenault)
- Updated composer to properly namespace our tests
- Updated the PHPUnit config to fix the "missing name attribute" warning
- Removed unused method from `UsersTest`
