### PR TITLE
Add CS check to `make test`. Should run in CI now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .SILENT: ;
 
-test: test-phpunit test-phpspec
+test: cs-check test-phpunit test-phpspec
+
+cs-check:
+	vendor/bin/php-cs-fixer fix --dry-run --stop-on-violation
 
 test-phpunit:
 	vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 test: cs-check test-phpunit test-phpspec
 
 cs-check:
-	vendor/bin/php-cs-fixer fix --dry-run --stop-on-violation
+	vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run
 
 test-phpunit:
 	vendor/bin/phpunit


### PR DESCRIPTION
Fixes #23 

I believe I found the right way to have CI run `php-cs-fixer`. I've updated the `MAKEFILE` to do a dry run of the fixer (don't actually change files on disk) and stop if it would have changed anything. This should cause CI to fail when CS fixes are needed, preventing the need for bulk fix PRs like #63 

I'd like to wait until #63 is in place before merging this in.

FYI @brandinarsenault So you know to expect this change, with the amount you've been helping with this library.