### PR TITLE
Add Endpoints startCommercial and createClip, Removed Optional Bearer

### DIFF
--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -6,6 +6,7 @@ namespace NewTwitchApi;
 
 use GuzzleHttp\Client;
 use NewTwitchApi\Auth\OauthApi;
+use NewTwitchApi\Resources\AdsApi;
 use NewTwitchApi\Resources\BitsApi;
 use NewTwitchApi\Resources\ClipsApi;
 use NewTwitchApi\Resources\GamesApi;
@@ -22,6 +23,7 @@ use NewTwitchApi\Webhooks\WebhooksSubscriptionApi;
 class NewTwitchApi
 {
     private $oauthApi;
+    private $adsApi;
     private $bitsApi;
     private $clipsApi;
     private $gamesApi;
@@ -38,6 +40,7 @@ class NewTwitchApi
     public function __construct(Client $helixGuzzleClient, string $clientId, string $clientSecret, Client $authGuzzleClient = null)
     {
         $this->oauthApi = new OauthApi($clientId, $clientSecret, $authGuzzleClient);
+        $this->adsApi = new AdsApi($helixGuzzleClient);
         $this->bitsApi = new BitsApi($helixGuzzleClient);
         $this->clipsApi = new ClipsApi($helixGuzzleClient);
         $this->gamesApi = new GamesApi($helixGuzzleClient);
@@ -55,6 +58,11 @@ class NewTwitchApi
     public function getOauthApi(): OauthApi
     {
         return $this->oauthApi;
+    }
+
+    public function getAdsApi(): AdsApi
+    {
+        return $this->adsApi;
     }
 
     public function getBitsApi(): BitsApi

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -26,7 +26,21 @@ abstract class AbstractResource
         $request = new Request(
             'GET',
             sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            $bearer ? ['Authorization' => sprintf('Bearer %s', $bearer)] : []
+            ['Authorization' => sprintf('Bearer %s', $bearer)]
+        );
+
+        return $this->guzzleClient->send($request);
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    protected function postApi(string $uriEndpoint, string $bearer, array $queryParamsMap = []): ResponseInterface
+    {
+        $request = new Request(
+            'POST',
+            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+            ['Authorization' => sprintf('Bearer %s', $bearer)]
         );
 
         return $this->guzzleClient->send($request);

--- a/src/NewTwitchApi/Resources/AdsApi.php
+++ b/src/NewTwitchApi/Resources/AdsApi.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class AdsApi extends AbstractResource
+{
+
+    /**
+    * @throws GuzzleException
+    * @link https://dev.twitch.tv/docs/api/reference#start-commercial
+    */
+    public function startCommercial(string $bearer, string $broadcasterId, int $length): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        $queryParamsMap[] = ['key' => 'length', 'value' => $length];
+
+        return $this->postApi('channels/commercial', $bearer, $queryParamsMap);
+    }
+}

--- a/src/NewTwitchApi/Resources/ClipsApi.php
+++ b/src/NewTwitchApi/Resources/ClipsApi.php
@@ -67,4 +67,21 @@ class ClipsApi extends AbstractResource
 
         return $this->callApi('clips', $bearer, $queryParamsMap);
     }
+
+    /**
+    * @throws GuzzleException
+    * @link https://dev.twitch.tv/docs/api/reference#create-clip
+    */
+    public function createClip(string $bearer, string $broadcasterId, boolean $hasDelay = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        if ($hasDelay) {
+            $queryParamsMap[] = ['key' => 'has_delay', 'value' => $hasDelay];
+        }
+
+        return $this->postApi('clips', $bearer, $queryParamsMap);
+    }
 }


### PR DESCRIPTION
- Added `AbstractResource->postApi` for Post API calls
- Added `NewTwitchApi->getAdsApi`
- Added `AdsApi->startCommercial` 
- Added `ClipsApi->createClip`
- Removed Optional Bearer from AbstractResource, Enforced