### PR TITLE
VideosApi parameter fix

### DIFF
--- a/src/NewTwitchApi/Resources/VideosApi.php
+++ b/src/NewTwitchApi/Resources/VideosApi.php
@@ -54,7 +54,7 @@ class VideosApi extends AbstractResource
             $queryParamsMap[] = ['key' => 'sort', 'value' => $sort];
         }
 
-        if ($sort) {
+        if ($type) {
             $queryParamsMap[] = ['key' => 'type', 'value' => $type];
         }
 


### PR DESCRIPTION
The `type` parameter of the `getVideos()` call of the VideosApi is never parsed due to an apparent copy/paste mistake.
Fixed that in this PR.