### PR TITLE
Add Get Stream Tags endpoint support

### DIFF
--- a/src/NewTwitchApi/Resources/StreamsApi.php
+++ b/src/NewTwitchApi/Resources/StreamsApi.php
@@ -153,4 +153,17 @@ class StreamsApi extends AbstractResource
 
         return $this->callApi('channels', $bearer, $queryParamsMap);
     }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-stream-tags
+     */
+    public function getStreamTags(string $bearer, string $broadcasterId): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        return $this->callApi('streams/tags', $bearer, $queryParamsMap);
+    }
 }


### PR DESCRIPTION
Add support for the [Get Stream Tags](https://dev.twitch.tv/docs/api/reference#get-stream-tags) endpoint.