### PR TITLE
Updated php-cs-fixer rules and fixes

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,5 +6,13 @@ $finder = PhpCsFixer\Finder::create()
 ;
 
 return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        '@Symfony' => true,
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_no_alias_tag' => false,
+        'phpdoc_separation' => false,
+        'yoda_style' => false,
+    ])
     ->setFinder($finder)
 ;

--- a/src/NewTwitchApi/Auth/OauthApi.php
+++ b/src/NewTwitchApi/Auth/OauthApi.php
@@ -50,7 +50,7 @@ class OauthApi
                     'redirect_uri' => $redirectUri,
                     'code' => $code,
                     'state' => $state,
-                ]
+                ],
             ]
         );
     }
@@ -73,7 +73,7 @@ class OauthApi
         return $this->makeRequest(
             new Request('POST', 'token'),
             [
-                RequestOptions::JSON => $requestOptions
+                RequestOptions::JSON => $requestOptions,
             ]
         );
     }
@@ -88,7 +88,7 @@ class OauthApi
                 'GET',
                 'validate',
                 [
-                    'Authorization' => sprintf('OAuth %s', $accessToken)
+                    'Authorization' => sprintf('OAuth %s', $accessToken),
                 ]
             )
         );
@@ -115,7 +115,7 @@ class OauthApi
                     'client_secret' => $this->clientSecret,
                     'grant_type' => 'client_credentials',
                     'scope' => $scope,
-                ]
+                ],
             ]
         );
     }

--- a/src/NewTwitchApi/Resources/AdsApi.php
+++ b/src/NewTwitchApi/Resources/AdsApi.php
@@ -9,11 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class AdsApi extends AbstractResource
 {
-
     /**
-    * @throws GuzzleException
-    * @link https://dev.twitch.tv/docs/api/reference#start-commercial
-    */
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#start-commercial
+     */
     public function startCommercial(string $bearer, string $broadcasterId, int $length): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/BitsApi.php
+++ b/src/NewTwitchApi/Resources/BitsApi.php
@@ -9,11 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class BitsApi extends AbstractResource
 {
-
-  /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference#get-cheermotes
-  */
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-cheermotes
+     */
     public function getCheermotes(string $bearer, string $broadcasterId = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -26,9 +25,9 @@ class BitsApi extends AbstractResource
     }
 
     /**
-    * @throws GuzzleException
-    * @link https://dev.twitch.tv/docs/api/reference#get-bits-leaderboard
-    */
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-bits-leaderboard
+     */
     public function getBitsLeaderboard(string $bearer, int $count = null, string $period = null, string $startedAt = null, string $userId = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/ClipsApi.php
+++ b/src/NewTwitchApi/Resources/ClipsApi.php
@@ -69,10 +69,10 @@ class ClipsApi extends AbstractResource
     }
 
     /**
-    * @throws GuzzleException
-    * @link https://dev.twitch.tv/docs/api/reference#create-clip
-    */
-    public function createClip(string $bearer, string $broadcasterId, boolean $hasDelay = null): ResponseInterface
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#create-clip
+     */
+    public function createClip(string $bearer, string $broadcasterId, bool $hasDelay = null): ResponseInterface
     {
         $queryParamsMap = [];
 

--- a/src/NewTwitchApi/Resources/EntitlementsApi.php
+++ b/src/NewTwitchApi/Resources/EntitlementsApi.php
@@ -12,11 +12,12 @@ class EntitlementsApi extends AbstractResource
     /**
      * @throws GuzzleException
      */
-    public function getEntitlementGrantsUploadURL(string $bearer, string $manifestId, string $type = "bulk_drops_grant"): ResponseInterface
+    public function getEntitlementGrantsUploadURL(string $bearer, string $manifestId, string $type = 'bulk_drops_grant'): ResponseInterface
     {
         $queryParamsMap = [];
         $queryParamsMap[] = ['key' => 'manifest_id', 'value' => $manifestId];
         $queryParamsMap[] = ['key' => 'type', 'value' => $type];
+
         return $this->postApi('entitlements/upload', $bearer, $queryParamsMap);
     }
 }

--- a/src/NewTwitchApi/Resources/HypeTrainApi.php
+++ b/src/NewTwitchApi/Resources/HypeTrainApi.php
@@ -9,11 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class HypeTrainApi extends AbstractResource
 {
-
-  /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference#get-hype-train-events
-  */
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-hype-train-events
+     */
     public function getHypeTrainEvents(string $bearer, string $broadcasterId, int $first = null, string $id = null, string $cursor = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/ModerationApi.php
+++ b/src/NewTwitchApi/Resources/ModerationApi.php
@@ -9,11 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class ModerationApi extends AbstractResource
 {
-
-  /**
-   * @throws GuzzleException
-   * @link https://dev.twitch.tv/docs/api/reference/#get-banned-events
-   */
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-banned-events
+     */
     public function getBannedEvents(string $bearer, string $broadcasterId, array $ids = [], string $first = null, string $after = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -61,9 +60,9 @@ class ModerationApi extends AbstractResource
     }
 
     /**
-    * @throws GuzzleException
-    * @link https://dev.twitch.tv/docs/api/reference/#get-moderators
-    */
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-moderators
+     */
     public function getModerators(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -82,9 +81,9 @@ class ModerationApi extends AbstractResource
     }
 
     /**
-    * @throws GuzzleException
-    * @link https://dev.twitch.tv/docs/api/reference/#get-moderator-events
-    */
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-moderator-events
+     */
     public function getModeratorEvents(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/SearchApi.php
+++ b/src/NewTwitchApi/Resources/SearchApi.php
@@ -9,11 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class SearchApi extends AbstractResource
 {
-
-  /**
-  * @throws GuzzleException
-  * @link https://dev.twitch.tv/docs/api/reference#search-categories
-  */
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#search-categories
+     */
     public function searchCategories(string $bearer, string $query, string $first = null, string $after = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -32,9 +31,9 @@ class SearchApi extends AbstractResource
     }
 
     /**
-    * @throws GuzzleException
-    * @link https://dev.twitch.tv/docs/api/reference#search-channels
-    */
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#search-channels
+     */
     public function searchChannels(string $bearer, string $query, $liveOnly = null, string $first = null, string $after = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/StreamsApi.php
+++ b/src/NewTwitchApi/Resources/StreamsApi.php
@@ -32,7 +32,7 @@ class StreamsApi extends AbstractResource
     public function getStreamKey(string $bearer, string $broadcasterId): ResponseInterface
     {
         $queryParamsMap = [];
-        
+
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
         return $this->callApi('streams/key', $bearer, $queryParamsMap);

--- a/src/NewTwitchApi/Resources/SubscriptionsApi.php
+++ b/src/NewTwitchApi/Resources/SubscriptionsApi.php
@@ -9,11 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class SubscriptionsApi extends AbstractResource
 {
-
-  /**
-   * @throws GuzzleException
-   * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions
-   */
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions
+     */
     public function getBroadcasterSubscriptions(string $bearer, string $broadcasterId, int $first = null, string $after = null): ResponseInterface
     {
         $queryParamsMap = [];
@@ -30,11 +29,11 @@ class SubscriptionsApi extends AbstractResource
 
         return $this->callApi('subscriptions', $bearer, $queryParamsMap);
     }
+
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
      */
-
     public function getBroadcasterSubscribers(string $bearer, string $broadcasterId, array $ids = []): ResponseInterface
     {
         $queryParamsMap = [];
@@ -52,7 +51,6 @@ class SubscriptionsApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-subscription-events
      */
-
     public function getSubscriptionEvents(string $bearer, string $broadcasterId, string $eventId = null, string $userId = null, int $first = null, string $after = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/src/NewTwitchApi/Resources/VideosApi.php
+++ b/src/NewTwitchApi/Resources/VideosApi.php
@@ -9,11 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class VideosApi extends AbstractResource
 {
-
-  /**
-   * @throws GuzzleException
-   * @link https://dev.twitch.tv/docs/api/reference/#get-videos
-   */
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-videos
+     */
     public function getVideos(string $bearer, array $ids = [], string $userId = null, string $gameId = null, string $first = null, string $before = null, string $after = null, string $language = null, string $period = null, string $sort = null, string $type = null): ResponseInterface
     {
         $queryParamsMap = [];

--- a/test/NewTwitchApi/Resources/UsersTest.php
+++ b/test/NewTwitchApi/Resources/UsersTest.php
@@ -54,8 +54,9 @@ class UsersTest extends TestCase
 JSON;
 
         $db_response = new Response(200, [], $getUserReponseJson);
-        $mock = new MockHandler([ $db_response, $db_response ]);
+        $mock = new MockHandler([$db_response, $db_response]);
         $handler = HandlerStack::create($mock);
+
         return new Client(['handler' => $handler]);
     }
 }


### PR DESCRIPTION
There's been a bit of messy code added, myself included, so I'm updating the php-cs-fixer rules to fix that, so we can keep the code base clean and consistent. 

Mostly what's being fixed here is:

- Indentation and spacing
- Use `'` instead of `"` 
- Trailing commas
- Blank line before `return`

What I've done is enable the `@Symfony` rules, with a few exceptions:
- Disabled `phpdoc_annotation_without_dot`
- Disabled `phpdoc_no_alias_tag`
- Disabled `phpdoc_separation`
- Disabled `yoda_style`

Rule descriptions can be found here: https://github.com/FriendsOfPhp/PHP-CS-Fixer#rules