### PR TITLE
Add bodyParams and Function Updates

### DIFF
--- a/spec/NewTwitchApi/Resources/UsersApiSpec.php
+++ b/spec/NewTwitchApi/Resources/UsersApiSpec.php
@@ -122,4 +122,10 @@ class UsersApiSpec extends ObjectBehavior
         $guzzleClient->send(new Request('POST', 'users/follows?from_id=123&to_id=321&allow_notifications=0', ['Authorization' => 'Bearer TEST_TOKEN']))->willReturn($response);
         $this->createUserFollow('TEST_TOKEN', '123', '321', false)->shouldBeAnInstanceOf(ResponseInterface::class);
     }
+
+    function it_should_delete_a_follow(Client $guzzleClient, Response $response)
+    {
+        $guzzleClient->send(new Request('DELETE', 'users/follows?from_id=123&to_id=321', ['Authorization' => 'Bearer TEST_TOKEN']))->willReturn($response);
+        $this->deleteUserFollow('TEST_TOKEN', '123', '321')->shouldBeAnInstanceOf(ResponseInterface::class);
+    }
 }

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -23,15 +23,23 @@ abstract class AbstractResource
      */
     protected function callApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
-        $request = new Request(
-            'GET',
-            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            [
-              'Authorization' => sprintf('Bearer %s', $bearer),
-              'Accept' => 'application/json',
-            ],
-            json_encode($bodyParams)
-        );
+        if (count($bodyParams) > 0) {
+            $request = new Request(
+              'GET',
+              sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+              [
+                'Authorization' => sprintf('Bearer %s', $bearer),
+                'Accept' => 'application/json',
+              ],
+              json_encode($bodyParams)
+          );
+        } else {
+            $request = new Request(
+              'GET',
+              sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+              ['Authorization' => sprintf('Bearer %s', $bearer)]
+          );
+        }
 
         return $this->guzzleClient->send($request);
     }
@@ -41,15 +49,23 @@ abstract class AbstractResource
      */
     protected function deleteApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
-        $request = new Request(
-                'DELETE',
-                sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-                [
-                  'Authorization' => sprintf('Bearer %s', $bearer),
-                  'Accept' => 'application/json',
-                ],
-                json_encode($bodyParams)
-            );
+        if (count($bodyParams) > 0) {
+            $request = new Request(
+            'DELETE',
+            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+            [
+              'Authorization' => sprintf('Bearer %s', $bearer),
+              'Accept' => 'application/json',
+            ],
+            json_encode($bodyParams)
+        );
+        } else {
+            $request = new Request(
+            'DELETE',
+            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+            ['Authorization' => sprintf('Bearer %s', $bearer)]
+        );
+        }
 
         return $this->guzzleClient->send($request);
     }
@@ -59,7 +75,8 @@ abstract class AbstractResource
      */
     protected function postApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
-        $request = new Request(
+        if (count($bodyParams) > 0) {
+            $request = new Request(
             'POST',
             sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
             [
@@ -68,6 +85,13 @@ abstract class AbstractResource
             ],
             json_encode($bodyParams)
         );
+        } else {
+            $request = new Request(
+            'POST',
+            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+            ['Authorization' => sprintf('Bearer %s', $bearer)]
+        );
+        }
 
         return $this->guzzleClient->send($request);
     }
@@ -77,7 +101,8 @@ abstract class AbstractResource
      */
     protected function putApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
-        $request = new Request(
+        if (count($bodyParams) > 0) {
+            $request = new Request(
             'PUT',
             sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
             [
@@ -86,6 +111,13 @@ abstract class AbstractResource
             ],
             json_encode($bodyParams)
         );
+        } else {
+            $request = new Request(
+            'PUT',
+            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+            ['Authorization' => sprintf('Bearer %s', $bearer)]
+        );
+        }
 
         return $this->guzzleClient->send($request);
     }

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -45,9 +45,22 @@ abstract class AbstractResource
     private function sendToApi(string $httpMethod, string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
         if (count($bodyParams) > 0) {
-            $request = new Request($httpMethod, sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)), ['Authorization' => sprintf('Bearer %s', $bearer), 'Accept' => 'application/json'], json_encode($bodyParams));
+            $request = new Request(
+              $httpMethod,
+              sprintf('%s%s',
+              $uriEndpoint,
+              $this->generateQueryParams($queryParamsMap)),
+              ['Authorization' => sprintf('Bearer %s', $bearer), 'Accept' => 'application/json'],
+              json_encode($bodyParams)
+            );
         } else {
-            $request = new Request($httpMethod, sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)), ['Authorization' => sprintf('Bearer %s', $bearer)]);
+            $request = new Request(
+              $httpMethod,
+              sprintf('%s%s',
+              $uriEndpoint,
+              $this->generateQueryParams($queryParamsMap)),
+              ['Authorization' => sprintf('Bearer %s', $bearer)]
+            );
         }
 
         return $this->guzzleClient->send($request);

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -23,25 +23,7 @@ abstract class AbstractResource
      */
     protected function callApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
-        if (count($bodyParams) > 0) {
-            $request = new Request(
-              'GET',
-              sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-              [
-                'Authorization' => sprintf('Bearer %s', $bearer),
-                'Accept' => 'application/json',
-              ],
-              json_encode($bodyParams)
-          );
-        } else {
-            $request = new Request(
-              'GET',
-              sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-              ['Authorization' => sprintf('Bearer %s', $bearer)]
-          );
-        }
-
-        return $this->guzzleClient->send($request);
+        return $this->sendToApi('GET', $uriEndpoint, $bearer, $queryParamsMap, $bodyParams);
     }
 
     /**
@@ -49,25 +31,7 @@ abstract class AbstractResource
      */
     protected function deleteApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
-        if (count($bodyParams) > 0) {
-            $request = new Request(
-            'DELETE',
-            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            [
-              'Authorization' => sprintf('Bearer %s', $bearer),
-              'Accept' => 'application/json',
-            ],
-            json_encode($bodyParams)
-        );
-        } else {
-            $request = new Request(
-            'DELETE',
-            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            ['Authorization' => sprintf('Bearer %s', $bearer)]
-        );
-        }
-
-        return $this->guzzleClient->send($request);
+        return $this->sendToApi('DELETE', $uriEndpoint, $bearer, $queryParamsMap, $bodyParams);
     }
 
     /**
@@ -75,48 +39,15 @@ abstract class AbstractResource
      */
     protected function postApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
-        if (count($bodyParams) > 0) {
-            $request = new Request(
-            'POST',
-            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            [
-              'Authorization' => sprintf('Bearer %s', $bearer),
-              'Accept' => 'application/json',
-            ],
-            json_encode($bodyParams)
-        );
-        } else {
-            $request = new Request(
-            'POST',
-            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            ['Authorization' => sprintf('Bearer %s', $bearer)]
-        );
-        }
-
-        return $this->guzzleClient->send($request);
+        return $this->sendToApi('POST', $uriEndpoint, $bearer, $queryParamsMap, $bodyParams);
     }
 
-    /**
-     * @throws GuzzleException
-     */
-    protected function putApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
+    private function sendToApi(string $httpMethod, string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
         if (count($bodyParams) > 0) {
-            $request = new Request(
-            'PUT',
-            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            [
-              'Authorization' => sprintf('Bearer %s', $bearer),
-              'Accept' => 'application/json',
-            ],
-            json_encode($bodyParams)
-        );
+            $request = new Request($httpMethod, sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)), ['Authorization' => sprintf('Bearer %s', $bearer), 'Accept' => 'application/json'], json_encode($bodyParams));
         } else {
-            $request = new Request(
-            'PUT',
-            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            ['Authorization' => sprintf('Bearer %s', $bearer)]
-        );
+            $request = new Request($httpMethod, sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)), ['Authorization' => sprintf('Bearer %s', $bearer)]);
         }
 
         return $this->guzzleClient->send($request);

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -46,20 +46,20 @@ abstract class AbstractResource
     {
         if (count($bodyParams) > 0) {
             $request = new Request(
-              $httpMethod,
-              sprintf('%s%s',
-              $uriEndpoint,
-              $this->generateQueryParams($queryParamsMap)),
-              ['Authorization' => sprintf('Bearer %s', $bearer), 'Accept' => 'application/json'],
-              json_encode($bodyParams)
+                $httpMethod,
+                sprintf('%s%s',
+                $uriEndpoint,
+                $this->generateQueryParams($queryParamsMap)),
+                ['Authorization' => sprintf('Bearer %s', $bearer), 'Accept' => 'application/json'],
+                json_encode($bodyParams)
             );
         } else {
             $request = new Request(
-              $httpMethod,
-              sprintf('%s%s',
-              $uriEndpoint,
-              $this->generateQueryParams($queryParamsMap)),
-              ['Authorization' => sprintf('Bearer %s', $bearer)]
+                $httpMethod,
+                sprintf('%s%s',
+                $uriEndpoint,
+                $this->generateQueryParams($queryParamsMap)),
+                ['Authorization' => sprintf('Bearer %s', $bearer)]
             );
         }
 

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -21,12 +21,16 @@ abstract class AbstractResource
     /**
      * @throws GuzzleException
      */
-    protected function callApi(string $uriEndpoint, string $bearer, array $queryParamsMap = []): ResponseInterface
+    protected function callApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
         $request = new Request(
             'GET',
             sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            ['Authorization' => sprintf('Bearer %s', $bearer)]
+            [
+              'Authorization' => sprintf('Bearer %s', $bearer),
+              'Accept' => 'application/json',
+            ],
+            json_encode($bodyParams)
         );
 
         return $this->guzzleClient->send($request);
@@ -35,12 +39,52 @@ abstract class AbstractResource
     /**
      * @throws GuzzleException
      */
-    protected function postApi(string $uriEndpoint, string $bearer, array $queryParamsMap = []): ResponseInterface
+    protected function deleteApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
+    {
+        $request = new Request(
+                'DELETE',
+                sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+                [
+                  'Authorization' => sprintf('Bearer %s', $bearer),
+                  'Accept' => 'application/json',
+                ],
+                json_encode($bodyParams)
+            );
+
+        return $this->guzzleClient->send($request);
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    protected function postApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
         $request = new Request(
             'POST',
             sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
-            ['Authorization' => sprintf('Bearer %s', $bearer)]
+            [
+              'Authorization' => sprintf('Bearer %s', $bearer),
+              'Accept' => 'application/json',
+            ],
+            json_encode($bodyParams)
+        );
+
+        return $this->guzzleClient->send($request);
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    protected function putApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
+    {
+        $request = new Request(
+            'PUT',
+            sprintf('%s%s', $uriEndpoint, $this->generateQueryParams($queryParamsMap)),
+            [
+              'Authorization' => sprintf('Bearer %s', $bearer),
+              'Accept' => 'application/json',
+            ],
+            json_encode($bodyParams)
         );
 
         return $this->guzzleClient->send($request);

--- a/src/NewTwitchApi/Resources/AdsApi.php
+++ b/src/NewTwitchApi/Resources/AdsApi.php
@@ -15,12 +15,12 @@ class AdsApi extends AbstractResource
      */
     public function startCommercial(string $bearer, string $broadcasterId, int $length): ResponseInterface
     {
-        $queryParamsMap = [];
+        $queryParamsMap = $bodyParamsMap = [];
 
-        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $bodyParamsMap[] = ['broadcaster_id' => $broadcasterId];
 
-        $queryParamsMap[] = ['key' => 'length', 'value' => $length];
+        $bodyParamsMap[] = ['length' => $length];
 
-        return $this->postApi('channels/commercial', $bearer, $queryParamsMap);
+        return $this->postApi('channels/commercial', $bearer, $queryParamsMap, $bodyParamsMap);
     }
 }

--- a/src/NewTwitchApi/Resources/AdsApi.php
+++ b/src/NewTwitchApi/Resources/AdsApi.php
@@ -15,12 +15,12 @@ class AdsApi extends AbstractResource
      */
     public function startCommercial(string $bearer, string $broadcasterId, int $length): ResponseInterface
     {
-        $queryParamsMap = $bodyParamsMap = [];
+        $bodyParamsMap = [];
 
         $bodyParamsMap[] = ['broadcaster_id' => $broadcasterId];
 
         $bodyParamsMap[] = ['length' => $length];
 
-        return $this->postApi('channels/commercial', $bearer, $queryParamsMap, $bodyParamsMap);
+        return $this->postApi('channels/commercial', $bearer, [], $bodyParamsMap);
     }
 }

--- a/src/NewTwitchApi/Resources/SubscriptionsApi.php
+++ b/src/NewTwitchApi/Resources/SubscriptionsApi.php
@@ -32,7 +32,7 @@ class SubscriptionsApi extends AbstractResource
 
     /**
      * @throws GuzzleException
-     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-s-subscribers
+     * @link https://dev.twitch.tv/docs/api/reference/#get-broadcaster-subscriptions
      */
     public function getBroadcasterSubscribers(string $bearer, string $broadcasterId, array $ids = []): ResponseInterface
     {

--- a/src/NewTwitchApi/Resources/UsersApi.php
+++ b/src/NewTwitchApi/Resources/UsersApi.php
@@ -120,4 +120,19 @@ class UsersApi extends AbstractResource
 
         return $this->postApi('users/follows', $bearer, $queryParamsMap);
     }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#delete-user-follows
+     */
+    public function deleteUserFollow(string $bearer, string $fromId, string $toId): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'from_id', 'value' => $fromId];
+
+        $queryParamsMap[] = ['key' => 'to_id', 'value' => $toId];
+
+        return $this->deleteApi('users/follows', $bearer, $queryParamsMap);
+    }
 }


### PR DESCRIPTION
- Added bodyParams to the Abstract Functions
- Added deleteApi function
- Fixed a bug with startCommercial #90 
- Resolved Doc Link issue in #76 
- Add Users: deleteUserFollow and Spec

The decision to use validation code in the Abstract Resource was made to avoid refactoring the tests. We could, naturally, just pass an empty body, however, this would require the rewriting of all of our tests to have an empty body. This could likely be improved in the future, for all of the calls, as we're repeating code in the Abstract quite frequently. 