### PR TITLE
Remove PHP 7.2, 7.3, add 8.0 to GHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.4', '8.0']
 
     steps:
       - uses: actions/checkout@v1
@@ -41,4 +41,3 @@ jobs:
 
       - name: Run tests
         run: make test
-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4']
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This PR resolves a test build issue related to PHP 7.2 and 7.3 by removing them from the `test.yaml`