### PR TITLE
Do not extend Guzzle\Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $twitch_client_id = 'TWITCH_CLIENT_ID';
 $twitch_client_secret = 'TWITCH_CLIENT_SECRET';
 $twitch_scopes = '';
 
-$helixGuzzleClient = new \NewTwitchApi\HelixGuzzleClient($twitch_client_id);
+$helixGuzzleClient = \NewTwitchApi\HelixGuzzleClient::getClient($twitch_client_id);
 $newTwitchApi = new \NewTwitchApi\NewTwitchApi($helixGuzzleClient, $twitch_client_id, $twitch_client_secret);
 $oauth = $newTwitchApi->getOauthApi();
 
@@ -62,7 +62,7 @@ $twitch_client_id = 'TWITCH_CLIENT_ID';
 $twitch_client_secret = 'TWITCH_CLIENT_SECRET';
 $twitch_scopes = '';
 
-$helixGuzzleClient = new \NewTwitchApi\HelixGuzzleClient($twitch_client_id);
+$helixGuzzleClient = \NewTwitchApi\HelixGuzzleClient::getClient($twitch_client_id);
 $newTwitchApi = new \NewTwitchApi\NewTwitchApi($helixGuzzleClient, $twitch_client_id, $twitch_client_secret);
 $oauth = $newTwitchApi->getOauthApi();
 
@@ -104,7 +104,7 @@ $twitch_client_secret = 'TWITCH_CLIENT_SECRET';
 $twitch_scopes = '';
 $user_refresh_token = 'REFRESH_TOKEN';
 
-$helixGuzzleClient = new \NewTwitchApi\HelixGuzzleClient($twitch_client_id);
+$helixGuzzleClient = \NewTwitchApi\HelixGuzzleClient::getClient($twitch_client_id);
 $newTwitchApi = new \NewTwitchApi\NewTwitchApi($helixGuzzleClient, $twitch_client_id, $twitch_client_secret);
 $oauth = $newTwitchApi->getOauthApi();
 
@@ -140,7 +140,7 @@ $twitch_access_token = 'the token';
 
 // The Guzzle client used can be the included `HelixGuzzleClient` class, for convenience.
 // You can also use a mock, fake, or other double for testing, of course.
-$helixGuzzleClient = new HelixGuzzleClient($twitch_client_id);
+$helixGuzzleClient = \NewTwitchApi\HelixGuzzleClient::getClient($twitch_client_id);
 
 // Instantiate NewTwitchApi. Can be done in a service layer and injected as well.
 $newTwitchApi = new NewTwitchApi($helixGuzzleClient, $twitch_client_id, $twitch_client_secret);

--- a/spec/NewTwitchApi/Auth/AuthGuzzleClientSpec.php
+++ b/spec/NewTwitchApi/Auth/AuthGuzzleClientSpec.php
@@ -9,6 +9,9 @@ class AuthGuzzleClientSpec extends ObjectBehavior
 {
     function it_should_have_correct_base_uri()
     {
+        $this->beConstructedThrough('getClient');
+        $this->shouldHaveType('\GuzzleHttp\Client');
+
         /** @var Uri $uri */
         $uri = $this->getConfig('base_uri');
         $uri->getScheme()->shouldBe('https');
@@ -18,7 +21,8 @@ class AuthGuzzleClientSpec extends ObjectBehavior
 
     function it_should_have_passed_in_config_params_instead_of_defaults()
     {
-        $this->beConstructedWith(['base_uri' => 'https://different.url']);
+        $this->beConstructedThrough('getClient', [['base_uri' => 'https://different.url']]);
+        $this->shouldHaveType('\GuzzleHttp\Client');
         $this->getConfig('base_uri')->getHost()->shouldBe('different.url');
     }
 }

--- a/spec/NewTwitchApi/HelixGuzzleClientSpec.php
+++ b/spec/NewTwitchApi/HelixGuzzleClientSpec.php
@@ -7,13 +7,11 @@ use PhpSpec\ObjectBehavior;
 
 class HelixGuzzleClientSpec extends ObjectBehavior
 {
-    function let()
-    {
-        $this->beConstructedWith('client-id');
-    }
-
     function it_should_have_correct_base_uri()
     {
+        $this->beConstructedThrough('getClient', ['client-id']);
+        $this->shouldHaveType('\GuzzleHttp\Client');
+
         /** @var Uri $uri */
         $uri = $this->getConfig('base_uri');
         $uri->getScheme()->shouldBe('https');
@@ -23,17 +21,22 @@ class HelixGuzzleClientSpec extends ObjectBehavior
 
     function it_should_have_client_id_header()
     {
+        $this->beConstructedThrough('getClient', ['client-id']);
+        $this->shouldHaveType('\GuzzleHttp\Client');
         $this->getConfig('headers')->shouldHaveKeyWithValue('Client-ID', 'client-id');
     }
 
     function it_should_have_json_content_type_header()
     {
+        $this->beConstructedThrough('getClient', ['client-id']);
+        $this->shouldHaveType('\GuzzleHttp\Client');
         $this->getConfig('headers')->shouldHaveKeyWithValue('Content-Type', 'application/json');
     }
 
     function it_should_have_passed_in_config_params_instead_of_defaults()
     {
-        $this->beConstructedWith('client-id', ['base_uri' => 'https://different.url']);
+        $this->beConstructedThrough('getClient', ['client-id', ['base_uri' => 'https://different.url']]);
+        $this->shouldHaveType('\GuzzleHttp\Client');
         $this->getConfig('base_uri')->getHost()->shouldBe('different.url');
     }
 }

--- a/src/NewTwitchApi/Auth/AuthGuzzleClient.php
+++ b/src/NewTwitchApi/Auth/AuthGuzzleClient.php
@@ -6,13 +6,13 @@ namespace NewTwitchApi\Auth;
 
 use GuzzleHttp\Client;
 
-class AuthGuzzleClient extends Client
+class AuthGuzzleClient
 {
     private const BASE_URI = 'https://id.twitch.tv/oauth2/';
 
-    public function __construct(array $config = [])
+    public static function getClient(array $config = []): Client
     {
-        parent::__construct($config + [
+        return new Client($config + [
             'base_uri' => self::BASE_URI,
         ]);
     }

--- a/src/NewTwitchApi/Auth/OauthApi.php
+++ b/src/NewTwitchApi/Auth/OauthApi.php
@@ -20,7 +20,7 @@ class OauthApi
     {
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
-        $this->guzzleClient = $guzzleClient ?? new AuthGuzzleClient();
+        $this->guzzleClient = $guzzleClient ?? AuthGuzzleClient::getClient();
     }
 
     /**

--- a/src/NewTwitchApi/HelixGuzzleClient.php
+++ b/src/NewTwitchApi/HelixGuzzleClient.php
@@ -6,13 +6,13 @@ namespace NewTwitchApi;
 
 use GuzzleHttp\Client;
 
-class HelixGuzzleClient extends Client
+class HelixGuzzleClient
 {
     private const BASE_URI = 'https://api.twitch.tv/helix/';
 
-    public function __construct(string $clientId, array $config = [])
+    public static function getClient(string $clientId, array $config = []): Client
     {
-        parent::__construct($config + [
+        return new Client($config + [
             'base_uri' => self::BASE_URI,
             'timeout' => 30,
             'headers' => ['Client-ID' => $clientId, 'Content-Type' => 'application/json'],

--- a/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
+++ b/src/NewTwitchApi/Webhooks/WebhooksSubscriptionApi.php
@@ -20,7 +20,7 @@ class WebhooksSubscriptionApi
     {
         $this->clientId = $clientId;
         $this->secret = $secret;
-        $this->guzzleClient = $guzzleClient ?? new HelixGuzzleClient($clientId);
+        $this->guzzleClient = $guzzleClient ?? HelixGuzzleClient::getClient($clientId);
     }
 
     public function subscribeToStream(string $twitchId, string $callback, string $bearer, int $leaseSeconds = 0): void


### PR DESCRIPTION
I am proposing a small PR to fix a deprecation warning when using Guzzle 7.1+

> User Deprecated: The "GuzzleHttp\Client" class is considered final. It may change without further notice as of 
its next major version. You should not extend it from "NewTwitchApi\Auth\AuthGuzzleClient".

Extending Guzzle\Client is deprecated since Guzzle 7.1 and [the class is annotated as @final](https://github.com/guzzle/guzzle/blob/master/src/Client.php#L15). The class will be actually final in Guzzle 8.0.

See guzzle/guzzle#2521

This would be a BC change, but since [you're thinking of making a 5.0 release](https://github.com/nicklaw5/twitch-api-php/pull/117#issuecomment-849874108), this would be the time.