### PR TITLE
v5.0.5: Add Schedules API

### DIFF
--- a/spec/NewTwitchApi/NewTwitchApiSpec.php
+++ b/spec/NewTwitchApi/NewTwitchApiSpec.php
@@ -16,6 +16,7 @@ use NewTwitchApi\Resources\GamesApi;
 use NewTwitchApi\Resources\ModerationApi;
 use NewTwitchApi\Resources\PollsApi;
 use NewTwitchApi\Resources\PredictionsApi;
+use NewTwitchApi\Resources\ScheduleApi;
 use NewTwitchApi\Resources\StreamsApi;
 use NewTwitchApi\Resources\SubscriptionsApi;
 use NewTwitchApi\Resources\TagsApi;
@@ -86,6 +87,11 @@ class NewTwitchApiSpec extends ObjectBehavior
     function it_should_provide_predictions_api()
     {
         $this->getPredictionsApi()->shouldBeAnInstanceOf(PredictionsApi::class);
+    }
+
+    function it_should_provide_schedule_api()
+    {
+        $this->getScheduleApi()->shouldBeAnInstanceOf(ScheduleApi::class);
     }
 
     function it_should_provide_subscriptions_api()

--- a/spec/NewTwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/NewTwitchApi/Resources/EventSubApiSpec.php
@@ -93,7 +93,7 @@ class EventSubApiSpec extends ObjectBehavior
 
     function it_should_subscribe_to_channel_subscription_message(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $this->createEventSubSubscription('channel.subscription.message', 'beta', ['broadcaster_user_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->createEventSubSubscription('channel.subscription.message', '1', ['broadcaster_user_id' => '12345'], $requestGenerator)->willReturn($request);
         $this->subscribeToChannelSubscriptionMessage($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
     }
 

--- a/spec/NewTwitchApi/Resources/ScheduleApiSpec.php
+++ b/spec/NewTwitchApi/Resources/ScheduleApiSpec.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace spec\NewTwitchApi\Resources;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use NewTwitchApi\RequestGenerator;
+use NewTwitchApi\HelixGuzzleClient;
+use PhpSpec\ObjectBehavior;
+
+class ScheduleApiSpec extends ObjectBehavior
+{
+    function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->beConstructedWith($guzzleClient, $requestGenerator);
+        $guzzleClient->send($request)->willReturn($response);
+    }
+
+    function it_should_get_channel_stream_schedule(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'schedule', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getChannelStreamSchedule('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_channel_stream_schedule_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'schedule', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'start_time', 'value' => '2021-06-15T23:08:20+00:00'], ['key' => 'utc_offset', 'value' => '240'], ['key' => 'first', 'value' => 25], ['key' => 'after', 'value' => 'abc']], [])->willReturn($request);
+        $this->getChannelStreamSchedule('TEST_TOKEN', '123', [], '2021-06-15T23:08:20+00:00', '240', 25, 'abc')->shouldBe($response);
+    }
+
+    function it_should_get_a_channel_stream_schedule(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'schedule', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'id', 'value' => '456']], [])->willReturn($request);
+        $this->getChannelStreamSchedule('TEST_TOKEN', '123', ['456'])->shouldBe($response);
+    }
+
+    function it_should_get_multiple_channel_stream_schedules(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'schedule', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'id', 'value' => '456'], ['key' => 'id', 'value' => '789']], [])->willReturn($request);
+        $this->getChannelStreamSchedule('TEST_TOKEN', '123', ['456', '789'])->shouldBe($response);
+    }
+
+    function it_should_get_channel_icalendar_with_no_auth(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'schedule/icalendar', null, [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getChanneliCalendar(null, '123')->shouldBe($response);
+    }
+
+    function it_should_get_channel_icalendar_with_auth(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'schedule/icalendar', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getChanneliCalendar('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_update_channel_stream_schedule(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PATCH', 'schedule/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'is_vacation_enabled', 'value' => true], ['key' => 'vacation_start_time', 'value' => '2021-06-15T23:08:20+00:00'], ['key' => 'vacation_end_time', 'value' => '2021-06-22T23:08:20+00:00'], ['key' => 'timezone', 'value' => 'America/New_York']], [])->willReturn($request);
+        $this->updateChannelStreamSchedule('TEST_TOKEN', '123', true, '2021-06-15T23:08:20+00:00', '2021-06-22T23:08:20+00:00', 'America/New_York')->shouldBe($response);
+    }
+
+    function it_should_create_channel_stream_schedule_segment(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'schedule/segment', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [['key' => 'start_time', 'value' => '2021-06-15T23:08:20+00:00'], ['key' => 'timezone', 'value' => 'America/New_York'], ['key' => 'is_recurring', 'value' => true]])->willReturn($request);
+        $this->createChannelStreamScheduleSegment('TEST_TOKEN', '123', '2021-06-15T23:08:20+00:00', 'America/New_York', true)->shouldBe($response);
+    }
+
+    function it_should_create_channel_stream_schedule_segment_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'schedule/segment', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [['key' => 'start_time', 'value' => '2021-06-15T23:08:20+00:00'], ['key' => 'timezone', 'value' => 'America/New_York'], ['key' => 'is_recurring', 'value' => true], ['key' => 'duration', 'value' => '240']])->willReturn($request);
+        $this->createChannelStreamScheduleSegment('TEST_TOKEN', '123', '2021-06-15T23:08:20+00:00', 'America/New_York', true, ['duration' => '240'])->shouldBe($response);
+    }
+
+    function it_should_update_channel_stream_schedule_segment(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PATCH', 'schedule/segment', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'id', 'value' => '456']], [['key' => 'start_time', 'value' => '2021-06-15T23:08:20+00:00'], ['key' => 'timezone', 'value' => 'America/New_York'], ['key' => 'is_canceled', 'value' => true], ['key' => 'duration', 'value' => '240']])->willReturn($request);
+        $this->updateChannelStreamScheduleSegment('TEST_TOKEN', '123', '456', ['start_time' => '2021-06-15T23:08:20+00:00', 'timezone' => 'America/New_York', 'is_canceled' => true, 'duration' => '240'])->shouldBe($response);
+    }
+
+    function it_should_delete_channel_stream_schedule_segment(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'schedule/segment', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'id', 'value' => '456']], [])->willReturn($request);
+        $this->deleteChannelStreamScheduleSegment('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+}

--- a/src/NewTwitchApi/NewTwitchApi.php
+++ b/src/NewTwitchApi/NewTwitchApi.php
@@ -20,6 +20,7 @@ use NewTwitchApi\Resources\HypeTrainApi;
 use NewTwitchApi\Resources\ModerationApi;
 use NewTwitchApi\Resources\PollsApi;
 use NewTwitchApi\Resources\PredictionsApi;
+use NewTwitchApi\Resources\ScheduleApi;
 use NewTwitchApi\Resources\SearchApi;
 use NewTwitchApi\Resources\StreamsApi;
 use NewTwitchApi\Resources\SubscriptionsApi;
@@ -47,6 +48,7 @@ class NewTwitchApi
     private $moderationApi;
     private $pollsApi;
     private $predictionsApi;
+    private $scheduleApi;
     private $searchApi;
     private $streamsApi;
     private $subscriptionsApi;
@@ -75,6 +77,7 @@ class NewTwitchApi
         $this->moderationApi = new ModerationApi($helixGuzzleClient, $requestGenerator);
         $this->pollsApi = new PollsApi($helixGuzzleClient, $requestGenerator);
         $this->predictionsApi = new PredictionsApi($helixGuzzleClient, $requestGenerator);
+        $this->scheduleApi = new ScheduleApi($helixGuzzleClient, $requestGenerator);
         $this->searchApi = new SearchApi($helixGuzzleClient, $requestGenerator);
         $this->streamsApi = new StreamsApi($helixGuzzleClient, $requestGenerator);
         $this->subscriptionsApi = new SubscriptionsApi($helixGuzzleClient, $requestGenerator);
@@ -159,6 +162,11 @@ class NewTwitchApi
     public function getPredictionsApi(): PredictionsApi
     {
         return $this->predictionsApi;
+    }
+
+    public function getScheduleApi(): ScheduleApi
+    {
+        return $this->scheduleApi;
     }
 
     public function getSearchApi(): SearchApi

--- a/src/NewTwitchApi/RequestGenerator.php
+++ b/src/NewTwitchApi/RequestGenerator.php
@@ -7,8 +7,16 @@ use Psr\Http\Message\RequestInterface;
 
 class RequestGenerator
 {
-    public function generate(string $httpMethod, string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): RequestInterface
+    public function generate(string $httpMethod, string $uriEndpoint, string $bearer = null, array $queryParamsMap = [], array $bodyParams = []): RequestInterface
     {
+        $headers = [
+          'Accept' => 'application/json',
+        ];
+
+        if ($bearer) {
+            $headers['Authorization'] = sprintf('Bearer %s', $bearer);
+        }
+
         if (count($bodyParams) > 0) {
             $request = new Request(
                 $httpMethod,
@@ -17,7 +25,7 @@ class RequestGenerator
                     $uriEndpoint,
                     $this->generateQueryParams($queryParamsMap)
                 ),
-                ['Authorization' => sprintf('Bearer %s', $bearer), 'Accept' => 'application/json'],
+                $headers,
                 $this->generateBodyParams($bodyParams)
             );
         } else {
@@ -28,7 +36,7 @@ class RequestGenerator
                     $uriEndpoint,
                     $this->generateQueryParams($queryParamsMap)
                 ),
-                ['Authorization' => sprintf('Bearer %s', $bearer)]
+                $headers
             );
         }
 

--- a/src/NewTwitchApi/Resources/AbstractResource.php
+++ b/src/NewTwitchApi/Resources/AbstractResource.php
@@ -31,6 +31,14 @@ abstract class AbstractResource
     /**
      * @throws GuzzleException
      */
+    protected function getApiWithOptionalAuth(string $uriEndpoint, string $bearer = null, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
+    {
+        return $this->sendToApi('GET', $uriEndpoint, $bearer, $queryParamsMap, $bodyParams);
+    }
+
+    /**
+     * @throws GuzzleException
+     */
     protected function deleteApi(string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
         return $this->sendToApi('DELETE', $uriEndpoint, $bearer, $queryParamsMap, $bodyParams);
@@ -60,7 +68,7 @@ abstract class AbstractResource
         return $this->sendToApi('PUT', $uriEndpoint, $bearer, $queryParamsMap, $bodyParams);
     }
 
-    private function sendToApi(string $httpMethod, string $uriEndpoint, string $bearer, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
+    private function sendToApi(string $httpMethod, string $uriEndpoint, string $bearer = null, array $queryParamsMap = [], array $bodyParams = []): ResponseInterface
     {
         return $this->guzzleClient->send($this->requestGenerator->generate($httpMethod, $uriEndpoint, $bearer, $queryParamsMap, $bodyParams));
     }

--- a/src/NewTwitchApi/Resources/EventSubApi.php
+++ b/src/NewTwitchApi/Resources/EventSubApi.php
@@ -148,7 +148,7 @@ class EventSubApi extends AbstractResource
             $secret,
             $callback,
             'channel.subscription.message',
-            'beta',
+            '1',
             ['broadcaster_user_id' => $twitchId],
         );
     }

--- a/src/NewTwitchApi/Resources/ScheduleApi.php
+++ b/src/NewTwitchApi/Resources/ScheduleApi.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NewTwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class ScheduleApi extends AbstractResource
+{
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-channel-stream-schedule
+     */
+    public function getChannelStreamSchedule(string $bearer, string $broadcasterId, array $ids = [], string $startTime = null, string $utcOffset = null, int $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        foreach ($ids as $id) {
+            $queryParamsMap[] = ['key' => 'id', 'value' => $id];
+        }
+
+        if ($startTime) {
+            $queryParamsMap[] = ['key' => 'start_time', 'value' => $startTime];
+        }
+
+        if ($utcOffset) {
+            $queryParamsMap[] = ['key' => 'utc_offset', 'value' => $utcOffset];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->getApi('schedule', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-channel-icalendar
+     */
+    public function getChanneliCalendar(string $bearer = null, string $broadcasterId): ResponseInterface
+    {
+        // This endpoint at the time of addition does not require any authorization, so the bearer is null.
+        // However, to prevent a breaking update in the future, it will remain the first function parameter.
+        // You may simple pass NULL to this to bypass authentication.
+
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        return $this->getApiWithOptionalAuth('schedule/icalendar', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#update-channel-stream-schedule
+     */
+    public function updateChannelStreamSchedule(string $bearer, string $broadcasterId, bool $isVacationEnabled = null, $vacationStartTime = null, $vacationEndTime = null, $timezone = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        if ($isVacationEnabled) {
+            $queryParamsMap[] = ['key' => 'is_vacation_enabled', 'value' => $isVacationEnabled];
+        }
+
+        if ($vacationStartTime) {
+            $queryParamsMap[] = ['key' => 'vacation_start_time', 'value' => $vacationStartTime];
+        }
+
+        if ($vacationEndTime) {
+            $queryParamsMap[] = ['key' => 'vacation_end_time', 'value' => $vacationEndTime];
+        }
+
+        if ($timezone) {
+            $queryParamsMap[] = ['key' => 'timezone', 'value' => $timezone];
+        }
+
+        return $this->patchApi('schedule/settings', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#create-channel-stream-schedule-segment
+     */
+    public function createChannelStreamScheduleSegment(string $bearer, string $broadcasterId, string $startTime, string $timezone, bool $isRecurring, array $additionalBodyParams = []): ResponseInterface
+    {
+        // $additionalBodyParams should be a standard key => value format, eg. ['duration' => '240'];
+        $queryParamsMap = $bodyParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        $bodyParamsMap[] = ['key' => 'start_time', 'value' => $startTime];
+        $bodyParamsMap[] = ['key' => 'timezone', 'value' => $timezone];
+        $bodyParamsMap[] = ['key' => 'is_recurring', 'value' => $isRecurring];
+
+        foreach ($additionalBodyParams as $key => $value) {
+            $bodyParamsMap[] = ['key' => $key, 'value' => $value];
+        }
+
+        return $this->postApi('schedule/segment', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#update-channel-stream-schedule-segment
+     */
+    public function updateChannelStreamScheduleSegment(string $bearer, string $broadcasterId, string $segmentId, array $updateValues = []): ResponseInterface
+    {
+        // $updateValues should be a standard key => value format based on the values available on the documentation, eg. ['duration' => '240'];
+        $queryParamsMap = $bodyParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'id', 'value' => $segmentId];
+
+        foreach ($updateValues as $key => $value) {
+            $bodyParamsMap[] = ['key' => $key, 'value' => $value];
+        }
+
+        return $this->patchApi('schedule/segment', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#delete-channel-stream-schedule-segment
+     */
+    public function deleteChannelStreamScheduleSegment(string $bearer, string $broadcasterId, string $segmentId): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'id', 'value' => $segmentId];
+
+        return $this->deleteApi('schedule/segment', $bearer, $queryParamsMap);
+    }
+}


### PR DESCRIPTION
**CORE**
- Allow Optional Auth in Request Generator
- Cleanup Headers in Request Generator
- Added `getApiWithOptionalAuth` for explicit calls with optional authentication (since all endpoints but 1 require auth at this time)

**NEW FEATURES**
- Added `ScheduleApi`
- Added `ScheduleApi` -> `getChannelStreamSchedule`
- Added `ScheduleApi` -> `getChanneliCalendar` (optional auth)
- Added `ScheduleApi` -> `updateChannelStreamSchedule`
- Added `ScheduleApi` -> `createChannelStreamScheduleSegment`
- Added `ScheduleApi` -> `updateChannelStreamScheduleSegment`
- Added `ScheduleApi` -> `deleteChannelStreamScheduleSegment`

**CHANGES**
- Promote `EventSubApi` -> `channel.subscription.message` to v1