### PR TITLE
v7.0.0: Endpoint Coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0']
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ composer-test.lock
 vendor/
 .idea
 .DS_STORE
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,8 +5,9 @@ $finder = PhpCsFixer\Finder::create()
     ->in('test/')
 ;
 
-return PhpCsFixer\Config::create()
-    ->setRules([
+$config = new PhpCsFixer\Config();
+
+return $config->setRules([
         '@PSR2' => true,
         '@Symfony' => true,
         'phpdoc_annotation_without_dot' => false,

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 test: cs-check test-phpunit test-phpspec
 
 cs-check:
-	vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run
+	vendor/bin/php-cs-fixer fix --diff --dry-run
 
 test-phpunit:
 	vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "guzzlehttp/guzzle": "~6.0|~7.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.13",
+    "friendsofphp/php-cs-fixer": "^3.10",
     "phpspec/phpspec": "^7.2",
     "phpunit/phpunit": "^9.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.13",
-    "phpspec/phpspec": "^6.1",
-    "phpunit/phpunit": "^8.5"
+    "phpspec/phpspec": "^7.2",
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "guzzlehttp/guzzle": "~6.0|~7.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.10",
+    "friendsofphp/php-cs-fixer": "^2.13",
     "phpspec/phpspec": "^7.2",
     "phpunit/phpunit": "^9.5"
   },

--- a/spec/TwitchApi/Resources/ChatApiSpec.php
+++ b/spec/TwitchApi/Resources/ChatApiSpec.php
@@ -72,26 +72,26 @@ class ChatApiSpec extends ObjectBehavior
 
     function it_should_update_chat_settings_with_one_setting(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $requestGenerator->generate('PATCH', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], ['emote_mode' => true])->willReturn($request);
+        $requestGenerator->generate('PATCH', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'emote_mode', 'value' => true]])->willReturn($request);
         $this->updateChatSettings('TEST_TOKEN', '123', '456', ['emote_mode' => true])->shouldBe($response);
     }
 
     function it_should_update_chat_settings_with_multiple_settings(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $requestGenerator->generate('PATCH', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], ['emote_mode' => true, 'slow_mode_wait_time' => 10])->willReturn($request);
+        $requestGenerator->generate('PATCH', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'emote_mode', 'value' => true], ['key' => 'slow_mode_wait_time', 'value' => 10]])->willReturn($request);
         $this->updateChatSettings('TEST_TOKEN', '123', '456', ['emote_mode' => true, 'slow_mode_wait_time' => 10])->shouldBe($response);
     }
 
     function it_should_send_a_chat_announcement(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $requestGenerator->generate('POST', 'chat/announcements', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], ['message' => 'Hello World'])->willReturn($request);
-        $this->sendChatAnnouncement('TEST_TOKEN', '123', 'Hello World')->shouldBe($response);
+        $requestGenerator->generate('POST', 'chat/announcements', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'message', 'value' => 'Hello World']])->willReturn($request);
+        $this->sendChatAnnouncement('TEST_TOKEN', '123', '456', 'Hello World')->shouldBe($response);
     }
 
     function it_should_send_a_chat_announcement_with_a_color(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $requestGenerator->generate('POST', 'chat/announcements', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], ['message' => 'Hello World', 'color' => 'red'])->willReturn($request);
-        $this->sendChatAnnouncement('TEST_TOKEN', '123', 'Hello World', 'red')->shouldBe($response);
+        $requestGenerator->generate('POST', 'chat/announcements', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'message', 'value' => 'Hello World'], ['key' => 'color', 'value' => 'red']])->willReturn($request);
+        $this->sendChatAnnouncement('TEST_TOKEN', '123', '456', 'Hello World', 'red')->shouldBe($response);
     }
 
     function it_should_get_a_users_chat_color(RequestGenerator $requestGenerator, Request $request, Response $response)

--- a/spec/TwitchApi/Resources/ChatApiSpec.php
+++ b/spec/TwitchApi/Resources/ChatApiSpec.php
@@ -57,4 +57,52 @@ class ChatApiSpec extends ObjectBehavior
         $requestGenerator->generate('GET', 'chat/badges/global', 'TEST_TOKEN', [], [])->willReturn($request);
         $this->getGlobalChatBadges('TEST_TOKEN')->shouldBe($response);
     }
+
+    function it_should_get_chat_settings(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getChatSettings('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_chat_settings_with_moderator_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [])->willReturn($request);
+        $this->getChatSettings('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_update_chat_settings_with_one_setting(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PATCH', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], ['emote_mode' => true])->willReturn($request);
+        $this->updateChatSettings('TEST_TOKEN', '123', '456', ['emote_mode' => true])->shouldBe($response);
+    }
+
+    function it_should_update_chat_settings_with_multiple_settings(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PATCH', 'chat/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], ['emote_mode' => true, 'slow_mode_wait_time' => 10])->willReturn($request);
+        $this->updateChatSettings('TEST_TOKEN', '123', '456', ['emote_mode' => true, 'slow_mode_wait_time' => 10])->shouldBe($response);
+    }
+
+    function it_should_send_a_chat_announcement(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'chat/announcements', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], ['message' => 'Hello World'])->willReturn($request);
+        $this->sendChatAnnouncement('TEST_TOKEN', '123', 'Hello World')->shouldBe($response);
+    }
+
+    function it_should_send_a_chat_announcement_with_a_color(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'chat/announcements', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], ['message' => 'Hello World', 'color' => 'red'])->willReturn($request);
+        $this->sendChatAnnouncement('TEST_TOKEN', '123', 'Hello World', 'red')->shouldBe($response);
+    }
+
+    function it_should_get_a_users_chat_color(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'chat/color', 'TEST_TOKEN', [['key' => 'user_id', 'value' => '123']], [])->willReturn($request);
+        $this->getUserChatColor('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_update_a_users_chat_color(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PUT', 'chat/color', 'TEST_TOKEN', [['key' => 'user_id', 'value' => '123'], ['key' => 'color', 'value' => 'red']], [])->willReturn($request);
+        $this->updateUserChatColor('TEST_TOKEN', '123', 'red')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/TwitchApi/Resources/EventSubApiSpec.php
@@ -255,7 +255,7 @@ class EventSubApiSpec extends ObjectBehavior
 
     function it_should_subscribe_to_extension_bits_transaction_create(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $this->createEventSubSubscription('extension.bits_transaction.create', 'beta', ['extension_client_id' => 'deadbeef'], $requestGenerator)->willReturn($request);
+        $this->createEventSubSubscription('extension.bits_transaction.create', '1', ['extension_client_id' => 'deadbeef'], $requestGenerator)->willReturn($request);
         $this->subscribeToExtensionBitsTransactionCreate($this->bearer, $this->secret, $this->callback, 'deadbeef')->shouldBe($response);
     }
 

--- a/spec/TwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/TwitchApi/Resources/EventSubApiSpec.php
@@ -258,4 +258,16 @@ class EventSubApiSpec extends ObjectBehavior
         $this->createEventSubSubscription('extension.bits_transaction.create', 'beta', ['extension_client_id' => 'deadbeef'], $requestGenerator)->willReturn($request);
         $this->subscribeToExtensionBitsTransactionCreate($this->bearer, $this->secret, $this->callback, 'deadbeef')->shouldBe($response);
     }
+
+    function it_should_subscribe_to_user_authorization_revoke(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->createEventSubSubscription('user.authorization.revoke', '1', ['client_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->subscribeToUserAuthorizationRevoke($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
+    }
+
+    function it_should_subscribe_to_user_authorization_grant(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->createEventSubSubscription('user.authorization.grant', '1', ['client_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->subscribeToUserAuthorizationGrant($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/TwitchApi/Resources/EventSubApiSpec.php
@@ -55,6 +55,12 @@ class EventSubApiSpec extends ObjectBehavior
         $this->getEventSubSubscription('TEST_TOKEN', null, 'channel.update')->shouldBe($response);
     }
 
+    function it_should_get_event_sub_subscription_with_user_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'eventsub/subscriptions', 'TEST_TOKEN', [['key' => 'user_id', 'value' => '789']], [])->willReturn($request);
+        $this->getEventSubSubscription('TEST_TOKEN', null, null, null, '789')->shouldBe($response);
+    }
+
     function it_should_get_event_sub_subscription_with_after(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
         $requestGenerator->generate('GET', 'eventsub/subscriptions', 'TEST_TOKEN', [['key' => 'after', 'value' => 'abc']], [])->willReturn($request);

--- a/spec/TwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/TwitchApi/Resources/EventSubApiSpec.php
@@ -270,4 +270,22 @@ class EventSubApiSpec extends ObjectBehavior
         $this->createEventSubSubscription('user.authorization.grant', '1', ['client_id' => '12345'], $requestGenerator)->willReturn($request);
         $this->subscribeToUserAuthorizationGrant($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
     }
+
+    function it_should_subscribe_to_channel_goal_begin(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->createEventSubSubscription('channel.goal.begin', '1', ['broadcaster_user_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->subscribeToChannelGoalBegin($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
+    }
+
+    function it_should_subscribe_to_channel_goal_progress(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->createEventSubSubscription('channel.goal.progress', '1', ['broadcaster_user_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->subscribeToChannelGoalProgress($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
+    }
+
+    function it_should_subscribe_to_channel_goal_end(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->createEventSubSubscription('channel.goal.end', '1', ['broadcaster_user_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->subscribeToChannelGoalEnd($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/HypeTrainApiSpec.php
+++ b/spec/TwitchApi/Resources/HypeTrainApiSpec.php
@@ -24,7 +24,7 @@ class HypeTrainApiSpec extends ObjectBehavior
 
     function it_should_get_hype_train_events_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $requestGenerator->generate('GET', 'it_should_get_hype_train_events', 'TEST_TOKEN', 100, 'abc')->willReturn($request);
+        $requestGenerator->generate('GET', 'hypetrain/events', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'first', 'value' => 100], ['key' => 'cursor', 'value' => 'abc']], [])->willReturn($request);
         $this->getHypeTrainEvents('TEST_TOKEN', '123', 100, 'abc')->shouldBe($response);
     }
 }

--- a/spec/TwitchApi/Resources/HypeTrainApiSpec.php
+++ b/spec/TwitchApi/Resources/HypeTrainApiSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\TwitchApi\Resources;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TwitchApi\RequestGenerator;
+use TwitchApi\HelixGuzzleClient;
+use PhpSpec\ObjectBehavior;
+
+class HypeTrainApiSpec extends ObjectBehavior
+{
+    function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->beConstructedWith($guzzleClient, $requestGenerator);
+        $guzzleClient->send($request)->willReturn($response);
+    }
+
+    function it_should_get_hype_train_events(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'hypetrain/events', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getHypeTrainEvents('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_hype_train_events_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'it_should_get_hype_train_events', 'TEST_TOKEN', 100, 'abc')->willReturn($request);
+        $this->getHypeTrainEvents('TEST_TOKEN', '123', 100, 'abc')->shouldBe($response);
+    }
+}

--- a/spec/TwitchApi/Resources/ModerationApiSpec.php
+++ b/spec/TwitchApi/Resources/ModerationApiSpec.php
@@ -18,8 +18,8 @@ class ModerationApiSpec extends ObjectBehavior
 
     function it_should_check_automod_status(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $requestGenerator->generate('POST', 'moderation/enforcements/status', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [['key' => 'msg_id', 'value' => '456'], ['key' => 'msg_text', 'value' => 'test 123'], ['key' => 'user_id', 'value' => '789']])->willReturn($request);
-        $this->checkAutoModStatus('TEST_TOKEN', '123', '456', 'test 123', '789')->shouldBe($response);
+        $requestGenerator->generate('POST', 'moderation/enforcements/status', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [['key' => 'msg_id', 'value' => '456'], ['key' => 'msg_text', 'value' => 'test 123']])->willReturn($request);
+        $this->checkAutoModStatus('TEST_TOKEN', '123', '456', 'test 123')->shouldBe($response);
     }
 
     function it_should_release_held_message(RequestGenerator $requestGenerator, Request $request, Response $response)

--- a/spec/TwitchApi/Resources/ModerationApiSpec.php
+++ b/spec/TwitchApi/Resources/ModerationApiSpec.php
@@ -99,4 +99,52 @@ class ModerationApiSpec extends ObjectBehavior
         $requestGenerator->generate('DELETE', 'moderation/chat', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456'], ['key' => 'message_id', 'value' => '789']], [])->willReturn($request);
         $this->deleteChatMessages('TEST_TOKEN', '123', '456', '789')->shouldBe($response);
     }
+
+    function it_should_add_a_channel_moderator(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'moderation/moderators', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => '456']], [])->willReturn($request);
+        $this->addChannelModerator('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_remove_a_channel_moderator(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'moderation/moderators', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => '456']], [])->willReturn($request);
+        $this->removeChannelModerator('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_get_vips_for_a_channel(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'channels/vips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getVips('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_vips_for_a_channel_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'channels/vips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'first', 'value' => 100], ['key' => 'after', 'value' => 'abc']], [])->willReturn($request);
+        $this->getVips('TEST_TOKEN', '123', [], 100, 'abc')->shouldBe($response);
+    }
+
+    function it_should_get_vips_for_a_channel_with_one_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'channels/vips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => '456']], [])->willReturn($request);
+        $this->getVips('TEST_TOKEN', '123', ['456'])->shouldBe($response);
+    }
+
+    function it_should_get_vips_for_a_channel_with_multipe_ids(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'channels/vips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => '456'], ['key' => 'user_id', 'value' => '789']], [])->willReturn($request);
+        $this->getVips('TEST_TOKEN', '123', ['456', '789'])->shouldBe($response);
+    }
+
+    function it_should_add_vip_for_a_channel(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'channels/vips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => '456']], [])->willReturn($request);
+        $this->addChannelVip('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_remove_vip_for_a_channel(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'channels/vips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => '456']], [])->willReturn($request);
+        $this->removeChannelVip('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/ModerationApiSpec.php
+++ b/spec/TwitchApi/Resources/ModerationApiSpec.php
@@ -27,4 +27,16 @@ class ModerationApiSpec extends ObjectBehavior
         $requestGenerator->generate('POST', 'moderation/automod/message', 'TEST_TOKEN', [], [['key' => 'user_id', 'value' => '123'], ['key' => 'msg_id', 'value' => '456'], ['key' => 'action', 'value' => 'ALLOW']])->willReturn($request);
         $this->manageHeldAutoModMessage('TEST_TOKEN', '123', '456', 'ALLOW')->shouldBe($response);
     }
+
+    function it_should_ban_a_user(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'moderation/bans', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'user_id', 'value' => '789'], ['key' => 'reason', 'value' => 'abc']])->willReturn($request);
+        $this->banUser('TEST_TOKEN', '123', '456', '789', 'abc')->shouldBe($response);
+    }
+
+    function it_should_ban_a_user_with_a_duration(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'moderation/bans', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'user_id', 'value' => '789'], ['key' => 'reason', 'value' => 'abc'], ['key' => 'duration', 'value' => 300]])->willReturn($request);
+        $this->banUser('TEST_TOKEN', '123', '456', '789', 'abc', 300)->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/ModerationApiSpec.php
+++ b/spec/TwitchApi/Resources/ModerationApiSpec.php
@@ -87,4 +87,16 @@ class ModerationApiSpec extends ObjectBehavior
         $requestGenerator->generate('DELETE', 'moderation/blocked_terms', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456'], ['key' => 'id', 'value' => '789']], [])->willReturn($request);
         $this->removeBlockedTerm('TEST_TOKEN', '123', '456', '789')->shouldBe($response);
     }
+
+    function it_should_delete_chat_messages(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'moderation/chat', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [])->willReturn($request);
+        $this->deleteChatMessages('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_delete_chat_messages_with_message_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'moderation/chat', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456'], ['key' => 'message_id', 'value' => '789']], [])->willReturn($request);
+        $this->deleteChatMessages('TEST_TOKEN', '123', '456', '789')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/ModerationApiSpec.php
+++ b/spec/TwitchApi/Resources/ModerationApiSpec.php
@@ -39,4 +39,10 @@ class ModerationApiSpec extends ObjectBehavior
         $requestGenerator->generate('POST', 'moderation/bans', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'user_id', 'value' => '789'], ['key' => 'reason', 'value' => 'abc'], ['key' => 'duration', 'value' => 300]])->willReturn($request);
         $this->banUser('TEST_TOKEN', '123', '456', '789', 'abc', 300)->shouldBe($response);
     }
+
+    function it_should_unban_a_user(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'moderation/bans', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456'], ['key' => 'user_id', 'value' => '789']], [])->willReturn($request);
+        $this->unbanUser('TEST_TOKEN', '123', '456', '789')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/ModerationApiSpec.php
+++ b/spec/TwitchApi/Resources/ModerationApiSpec.php
@@ -45,4 +45,46 @@ class ModerationApiSpec extends ObjectBehavior
         $requestGenerator->generate('DELETE', 'moderation/bans', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456'], ['key' => 'user_id', 'value' => '789']], [])->willReturn($request);
         $this->unbanUser('TEST_TOKEN', '123', '456', '789')->shouldBe($response);
     }
+
+    function it_should_get_automod_settings(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'moderation/automod/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [])->willReturn($request);
+        $this->getAutoModSettings('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_update_automod_settings_with_one_setting(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PUT', 'moderation/automod/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'aggression', 'value' => 1]])->willReturn($request);
+        $this->updateAutoModSettings('TEST_TOKEN', '123', '456', ['aggression' => 1])->shouldBe($response);
+    }
+
+    function it_should_update_automod_settings_with_multiple_settings(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PUT', 'moderation/automod/settings', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'aggression', 'value' => 1], ['key' => 'bullying', 'value' => 2]])->willReturn($request);
+        $this->updateAutoModSettings('TEST_TOKEN', '123', '456', ['aggression' => 1, 'bullying' => 2])->shouldBe($response);
+    }
+
+    function it_should_get_blocked_terms(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'moderation/blocked_terms', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [])->willReturn($request);
+        $this->getBlockedTerms('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_get_blocked_terms_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'moderation/blocked_terms', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456'], ['key' => 'first', 'value' => 100], ['key' => 'after', 'value' => 'abc']], [])->willReturn($request);
+        $this->getBlockedTerms('TEST_TOKEN', '123', '456', 100, 'abc')->shouldBe($response);
+    }
+
+    function it_should_add_a_blocked_term(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'moderation/blocked_terms', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456']], [['key' => 'term', 'value' => 'abc']])->willReturn($request);
+        $this->addBlockedTerm('TEST_TOKEN', '123', '456', 'abc')->shouldBe($response);
+    }
+
+    function it_should_remove_a_blocked_term(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'moderation/blocked_terms', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'moderator_id', 'value' => '456'], ['key' => 'id', 'value' => '789']], [])->willReturn($request);
+        $this->removeBlockedTerm('TEST_TOKEN', '123', '456', '789')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/RaidsApiSpec.php
+++ b/spec/TwitchApi/Resources/RaidsApiSpec.php
@@ -8,7 +8,7 @@ use TwitchApi\RequestGenerator;
 use TwitchApi\HelixGuzzleClient;
 use PhpSpec\ObjectBehavior;
 
-class RaidApiSpec extends ObjectBehavior
+class RaidsApiSpec extends ObjectBehavior
 {
     function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
     {
@@ -18,7 +18,7 @@ class RaidApiSpec extends ObjectBehavior
 
     function it_should_start_a_raid(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $requestGenerator->generate('POST', 'raids', 'TEST_TOKEN', [['key' => 'to_broadcaster_id', 'value' => '123'], ['key' => 'from_broadcaster_id', 'value' => '456']], [])->willReturn($request);
+        $requestGenerator->generate('POST', 'raids', 'TEST_TOKEN', [['key' => 'from_broadcaster_id', 'value' => '123'], ['key' => 'to_broadcaster_id', 'value' => '456']], [])->willReturn($request);
         $this->startRaid('TEST_TOKEN', '123', '456')->shouldBe($response);
     }
 

--- a/spec/TwitchApi/Resources/RaidsApiSpec.php
+++ b/spec/TwitchApi/Resources/RaidsApiSpec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace spec\TwitchApi\Resources;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TwitchApi\RequestGenerator;
+use TwitchApi\HelixGuzzleClient;
+use PhpSpec\ObjectBehavior;
+
+class RaidApiSpec extends ObjectBehavior
+{
+    function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->beConstructedWith($guzzleClient, $requestGenerator);
+        $guzzleClient->send($request)->willReturn($response);
+    }
+
+    function it_should_start_a_raid(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'raids', 'TEST_TOKEN', [['key' => 'to_broadcaster_id', 'value' => '123'], ['key' => 'from_broadcaster_id', 'value' => '456']], [])->willReturn($request);
+        $this->startRaid('TEST_TOKEN', '123', '456')->shouldBe($response);
+    }
+
+    function it_should_cancel_a_raid(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('DELETE', 'raids', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->cancelRaid('TEST_TOKEN', '123')->shouldBe($response);
+    }
+}

--- a/spec/TwitchApi/Resources/WhispersApiSpec.php
+++ b/spec/TwitchApi/Resources/WhispersApiSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\TwitchApi\Resources;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TwitchApi\RequestGenerator;
+use TwitchApi\HelixGuzzleClient;
+use PhpSpec\ObjectBehavior;
+
+class WhispersApiSpec extends ObjectBehavior
+{
+    function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->beConstructedWith($guzzleClient, $requestGenerator);
+        $guzzleClient->send($request)->willReturn($response);
+    }
+
+    function it_should_send_a_whisper(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'whispers', 'TEST_TOKEN', [['key' => 'from_user_id', 'value' => '123'], ['key' => 'to_user_id', 'value' => '456']], [['key' => 'message', 'value' => 'abc']])->willReturn($request);
+        $this->sendWhisper('TEST_TOKEN', '123', '456', 'abc')->shouldBe($response);
+    }
+}

--- a/spec/TwitchApi/TwitchApiSpec.php
+++ b/spec/TwitchApi/TwitchApiSpec.php
@@ -13,6 +13,7 @@ use TwitchApi\Resources\ChannelsApi;
 use TwitchApi\Resources\EntitlementsApi;
 use TwitchApi\Resources\EventSubApi;
 use TwitchApi\Resources\GamesApi;
+use TwitchApi\Resources\HypeTrainApi;
 use TwitchApi\Resources\ModerationApi;
 use TwitchApi\Resources\PollsApi;
 use TwitchApi\Resources\PredictionsApi;
@@ -77,6 +78,10 @@ class TwitchApiSpec extends ObjectBehavior
     function it_should_provide_games_api()
     {
         $this->getGamesApi()->shouldBeAnInstanceOf(GamesApi::class);
+    }
+
+    function it_should_provide_hype_train_api() {
+        $this->getHypeTrainApi()->shouldBeAnInstanceOf(HypeTrainApi::class);
     }
 
     function it_should_provide_polls_api()

--- a/spec/TwitchApi/TwitchApiSpec.php
+++ b/spec/TwitchApi/TwitchApiSpec.php
@@ -17,6 +17,7 @@ use TwitchApi\Resources\HypeTrainApi;
 use TwitchApi\Resources\ModerationApi;
 use TwitchApi\Resources\PollsApi;
 use TwitchApi\Resources\PredictionsApi;
+use TwitchApi\Resources\RaidsApi;
 use TwitchApi\Resources\ScheduleApi;
 use TwitchApi\Resources\StreamsApi;
 use TwitchApi\Resources\SubscriptionsApi;
@@ -84,6 +85,11 @@ class TwitchApiSpec extends ObjectBehavior
         $this->getHypeTrainApi()->shouldBeAnInstanceOf(HypeTrainApi::class);
     }
 
+    function it_should_provide_moderation_api()
+    {
+        $this->getModerationApi()->shouldBeAnInstanceOf(ModerationApi::class);
+    }
+
     function it_should_provide_polls_api()
     {
         $this->getPollsApi()->shouldBeAnInstanceOf(PollsApi::class);
@@ -92,6 +98,11 @@ class TwitchApiSpec extends ObjectBehavior
     function it_should_provide_predictions_api()
     {
         $this->getPredictionsApi()->shouldBeAnInstanceOf(PredictionsApi::class);
+    }
+
+    function it_should_provide_raids_api()
+    {
+        $this->getRaidsApi()->shouldBeAnInstanceOf(RaidsApi::class);
     }
 
     function it_should_provide_schedule_api()

--- a/spec/TwitchApi/TwitchApiSpec.php
+++ b/spec/TwitchApi/TwitchApiSpec.php
@@ -26,6 +26,7 @@ use TwitchApi\Resources\TeamsApi;
 use TwitchApi\Resources\UsersApi;
 use TwitchApi\Resources\VideosApi;
 use TwitchApi\Resources\WebhooksApi;
+use TwitchApi\Resources\WhispersApi;
 use TwitchApi\Webhooks\WebhooksSubscriptionApi;
 use PhpSpec\ObjectBehavior;
 
@@ -143,6 +144,11 @@ class TwitchApiSpec extends ObjectBehavior
     function it_should_provide_webhooks_api()
     {
         $this->getWebhooksApi()->shouldBeAnInstanceOf(WebhooksApi::class);
+    }
+
+    function it_should_provide_whispers_api()
+    {
+        $this->getWhispersApi()->shouldBeAnInstanceOf(WhispersApi::class);
     }
 
     function it_should_provide_webhooks_subscription_api()

--- a/src/Resources/ChatApi.php
+++ b/src/Resources/ChatApi.php
@@ -94,14 +94,12 @@ class ChatApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#update-chat-settings
      */
-    public function updateChatSettings(string $bearer, string $broadcasterId, array $chatSettings, string $moderatorId = null): ResponseInterface
+    public function updateChatSettings(string $bearer, string $broadcasterId, string $moderatorId, array $chatSettings): ResponseInterface
     {
         $queryParamsMap = $bodyParamsMap = [];
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
 
-        if ($moderatorId) {
-            $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
-        }
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
 
         foreach ($chatSettings as $key => $value) {
             $bodyParamsMap[] = ['key' => $key, 'value' => $value];

--- a/src/Resources/ChatApi.php
+++ b/src/Resources/ChatApi.php
@@ -73,4 +73,89 @@ class ChatApi extends AbstractResource
     {
         return $this->getApi('chat/badges/global', $bearer);
     }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-chat-settings
+     */
+    public function getChatSettings(string $bearer, string $broadcasterId, string $moderatorId = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        if ($moderatorId) {
+            $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+        }
+
+        return $this->getApi('chat/settings', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#update-chat-settings
+     */
+    public function updateChatSettings(string $bearer, string $broadcasterId, array $chatSettings, string $moderatorId = null): ResponseInterface
+    {
+        $queryParamsMap = $bodyParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        if ($moderatorId) {
+            $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+        }
+
+        foreach ($chatSettings as $key => $value) {
+            $bodyParamsMap[] = ['key' => $key, 'value' => $value];
+        }
+
+        return $this->patchApi('chat/settings', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#send-chat-announcement
+     */
+    public function sendChatAnnouncement(string $bearer, string $broadcasterId, string $moderatorId, string $message, string $color = null): ResponseInterface
+    {
+        $queryParamsMap = $bodyParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+
+        $bodyParamsMap[] = ['key' => 'message', 'value' => $message];
+
+        if ($color) {
+            $bodyParamsMap[] = ['key' => 'color', 'value' => $color];
+        }
+
+        return $this->postApi('chat/announcements', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-user-chat-color
+     */
+    public function getUserChatColor(string $bearer, string $userId): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+
+        return $this->getApi('chat/color', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#update-user-chat-color
+     */
+    public function updateUserChatColor(string $bearer, string $userId, string $color): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+
+        $queryParamsMap[] = ['key' => 'color', 'value' => $color];
+
+        return $this->putApi('chat/color', $bearer, $queryParamsMap);
+    }
 }

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -13,7 +13,7 @@ class EventSubApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#get-eventsub-subscriptions
      */
-    public function getEventSubSubscription(string $bearer, string $status = null, string $type = null, string $after = null): ResponseInterface
+    public function getEventSubSubscription(string $bearer, string $status = null, string $type = null, string $after = null, string $userId = null): ResponseInterface
     {
         $queryParamsMap = [];
 
@@ -27,6 +27,10 @@ class EventSubApi extends AbstractResource
 
         if ($after) {
             $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        if ($userId) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
         }
 
         return $this->getApi('eventsub/subscriptions', $bearer, $queryParamsMap);

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -373,8 +373,6 @@ class EventSubApi extends AbstractResource
         return $this->subscribeToStream($bearer, $secret, $callback, $twitchId, 'offline');
     }
 
-
-
     /**
      * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userauthorizationrevoke
      */
@@ -578,5 +576,5 @@ class EventSubApi extends AbstractResource
             '1',
             ['broadcaster_user_id' => $twitchId],
         );
-    }    
+    }
 }

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -373,19 +373,22 @@ class EventSubApi extends AbstractResource
         return $this->subscribeToStream($bearer, $secret, $callback, $twitchId, 'offline');
     }
 
+
+
     /**
      * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userauthorizationrevoke
      */
     public function subscribeToUserAuthorizationRevoke(string $bearer, string $secret, string $callback, string $clientId): ResponseInterface
     {
-        return $this->createEventSubSubscription(
-            $bearer,
-            $secret,
-            $callback,
-            'user.authorization.revoke',
-            '1',
-            ['client_id' => $clientId],
-        );
+        return $this->subscribeToUserAuthorization($bearer, $secret, $callback, $clientId, 'revoke');
+    }
+
+    /**
+     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userauthorizationgrant
+     */
+    public function subscribeToUserAuthorizationGrant(string $bearer, string $secret, string $callback, string $clientId): ResponseInterface
+    {
+        return $this->subscribeToUserAuthorization($bearer, $secret, $callback, $clientId, 'grant');
     }
 
     /**
@@ -526,6 +529,18 @@ class EventSubApi extends AbstractResource
             sprintf('stream.%s', $eventType),
             '1',
             ['broadcaster_user_id' => $twitchId],
+        );
+    }
+
+    private function subscribeToUserAuthorization(string $bearer, string $secret, string $callback, string $clientId, string $eventType): ResponseInterface
+    {
+        return $this->createEventSubSubscription(
+            $bearer,
+            $secret,
+            $callback,
+            sprintf('user.authorization.%s', $eventType),
+            '1',
+            ['client_id' => $clientId],
         );
     }
 }

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -147,7 +147,7 @@ class EventSubApi extends AbstractResource
     }
 
     /**
-     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelsubscriptionmessage-beta
+     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelsubscriptionmessage
      */
     public function subscribeToChannelSubscriptionMessage(string $bearer, string $secret, string $callback, string $twitchId): ResponseInterface
     {
@@ -407,7 +407,7 @@ class EventSubApi extends AbstractResource
     }
 
     /**
-     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#extensionbits_transactioncreate-beta
+     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#extensionbits_transactioncreate
      */
     public function subscribeToExtensionBitsTransactionCreate(string $bearer, string $secret, string $callback, string $extensionClientId): ResponseInterface
     {
@@ -416,7 +416,7 @@ class EventSubApi extends AbstractResource
             $secret,
             $callback,
             'extension.bits_transaction.create',
-            'beta',
+            '1',
             ['extension_client_id' => $extensionClientId],
         );
     }

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -422,6 +422,30 @@ class EventSubApi extends AbstractResource
     }
 
     /**
+     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelgoalbegin
+     */
+    public function subscribeToChannelGoalBegin(string $bearer, string $secret, string $callback, string $twitchId): ResponseInterface
+    {
+        return $this->subscribeToChannelGoal($bearer, $secret, $callback, $twitchId, 'begin');
+    }
+
+    /**
+     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelgoalprogress
+     */
+    public function subscribeToChannelGoalProgress(string $bearer, string $secret, string $callback, string $twitchId): ResponseInterface
+    {
+        return $this->subscribeToChannelGoal($bearer, $secret, $callback, $twitchId, 'progress');
+    }
+
+    /**
+     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelgoalend
+     */
+    public function subscribeToChannelGoalEnd(string $bearer, string $secret, string $callback, string $twitchId): ResponseInterface
+    {
+        return $this->subscribeToChannelGoal($bearer, $secret, $callback, $twitchId, 'end');
+    }
+
+    /**
      * @link https://dev.twitch.tv/docs/eventsub#verify-a-signature
      */
     public function verifySignature(string $signature, string $secret, string $messageId, string $timestamp, string $body): bool
@@ -543,4 +567,16 @@ class EventSubApi extends AbstractResource
             ['client_id' => $clientId],
         );
     }
+
+    private function subscribeToChannelGoal(string $bearer, string $secret, string $callback, string $twitchId, string $eventType): ResponseInterface
+    {
+        return $this->createEventSubSubscription(
+            $bearer,
+            $secret,
+            $callback,
+            sprintf('channel.goal.%s', $eventType),
+            '1',
+            ['broadcaster_user_id' => $twitchId],
+        );
+    }    
 }

--- a/src/Resources/HypeTrainApi.php
+++ b/src/Resources/HypeTrainApi.php
@@ -13,7 +13,7 @@ class HypeTrainApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#get-hype-train-events
      */
-    public function getHypeTrainEvents(string $bearer, string $broadcasterId, int $first = null, string $id = null, string $cursor = null): ResponseInterface
+    public function getHypeTrainEvents(string $bearer, string $broadcasterId, int $first = null, string $cursor = null): ResponseInterface
     {
         $queryParamsMap = [];
 
@@ -23,14 +23,10 @@ class HypeTrainApi extends AbstractResource
             $queryParamsMap[] = ['key' => 'first', 'value' => $first];
         }
 
-        if ($id) {
-            $queryParamsMap[] = ['key' => 'id', 'value' => $id];
-        }
-
         if ($cursor) {
             $queryParamsMap[] = ['key' => 'cursor', 'value' => $cursor];
         }
 
-        return $this->getApi('bits/cheermotes', $bearer, $queryParamsMap);
+        return $this->getApi('hypetrain/events', $bearer, $queryParamsMap);
     }
 }

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -60,7 +60,7 @@ class ModerationApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#check-automod-status
      */
-    public function checkAutoModStatus(string $bearer, string $broadcasterId, string $msgId, string $msgText, string $userId): ResponseInterface
+    public function checkAutoModStatus(string $bearer, string $broadcasterId, string $msgId, string $msgText): ResponseInterface
     {
         $queryParamsMap = $bodyParamsMap = [];
 
@@ -68,7 +68,6 @@ class ModerationApi extends AbstractResource
 
         $bodyParamsMap[] = ['key' => 'msg_id', 'value' => $msgId];
         $bodyParamsMap[] = ['key' => 'msg_text', 'value' => $msgText];
-        $bodyParamsMap[] = ['key' => 'user_id', 'value' => $userId];
 
         return $this->postApi('moderation/enforcements/status', $bearer, $queryParamsMap, $bodyParamsMap);
     }

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -58,6 +58,32 @@ class ModerationApi extends AbstractResource
 
     /**
      * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#add-channel-moderator
+     */
+    public function addChannelModerator(string $bearer, string $broadcasterId, string $userId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        
+        return $this->postApi('moderation/moderators', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#remove-channel-moderator
+     */
+    public function removeChannelModerator(string $bearer, string $broadcasterId, string $userId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        
+        return $this->deleteApi('moderation/moderators', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#check-automod-status
      */
     public function checkAutoModStatus(string $bearer, string $broadcasterId, string $msgId, string $msgText): ResponseInterface
@@ -220,5 +246,57 @@ class ModerationApi extends AbstractResource
         }
 
         return $this->deleteApi('moderation/chat', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-vips
+     */
+    public function getVips(string $bearer, string $broadcasterId, array $users = [], int $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        
+        foreach($users as $user) {
+            $queryParamsMap[] = ['key' => 'user_id', 'value' => $user];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+        
+        return $this->getApi('channels/vips', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#add-channel-vip
+     */
+    public function addChannelVip(string $bearer, string $broadcasterId, string $userId): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        
+        return $this->postApi('channels/vips', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#remove-channel-vip
+     */
+    public function removeChannelVip(string $bearer, string $broadcasterId, string $userId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        
+        return $this->deleteApi('channels/vips', $bearer, $queryParamsMap);
     }
 }

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -86,4 +86,25 @@ class ModerationApi extends AbstractResource
 
         return $this->postApi('moderation/automod/message', $bearer, [], $bodyParamsMap);
     }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#ban-user
+     */
+    public function banUser(string $bearer, string $broadcasterId, string $moderatorId, string $userId, string $reason, int $duration = null): ResponseInterface
+    {
+        $queryParamsMap = $bodyParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+
+        $bodyParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+        $bodyParamsMap[] = ['key' => 'reason', 'value' => $reason];
+
+        if ($duration) {
+            $bodyParamsMap[] = ['key' => 'duration', 'value' => $duration];
+        }
+
+        return $this->postApi('moderation/bans', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
 }

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 
 class ModerationApi extends AbstractResource
 {
-
     /**
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-banned-users
@@ -65,7 +64,7 @@ class ModerationApi extends AbstractResource
         $queryParamsMap = [];
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
-        
+
         return $this->postApi('moderation/moderators', $bearer, $queryParamsMap);
     }
 
@@ -78,7 +77,7 @@ class ModerationApi extends AbstractResource
         $queryParamsMap = [];
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
-        
+
         return $this->deleteApi('moderation/moderators', $bearer, $queryParamsMap);
     }
 
@@ -240,7 +239,7 @@ class ModerationApi extends AbstractResource
         $queryParamsMap = [];
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
         $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
-        
+
         if ($messageId) {
             $queryParamsMap[] = ['key' => 'message_id', 'value' => $messageId];
         }
@@ -256,8 +255,8 @@ class ModerationApi extends AbstractResource
     {
         $queryParamsMap = [];
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
-        
-        foreach($users as $user) {
+
+        foreach ($users as $user) {
             $queryParamsMap[] = ['key' => 'user_id', 'value' => $user];
         }
 
@@ -268,7 +267,7 @@ class ModerationApi extends AbstractResource
         if ($after) {
             $queryParamsMap[] = ['key' => 'after', 'value' => $after];
         }
-        
+
         return $this->getApi('channels/vips', $bearer, $queryParamsMap);
     }
 
@@ -282,7 +281,7 @@ class ModerationApi extends AbstractResource
 
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
-        
+
         return $this->postApi('channels/vips', $bearer, $queryParamsMap);
     }
 
@@ -293,10 +292,10 @@ class ModerationApi extends AbstractResource
     public function removeChannelVip(string $bearer, string $broadcasterId, string $userId): ResponseInterface
     {
         $queryParamsMap = [];
-        
+
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
         $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
-        
+
         return $this->deleteApi('channels/vips', $bearer, $queryParamsMap);
     }
 }

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -107,4 +107,19 @@ class ModerationApi extends AbstractResource
 
         return $this->postApi('moderation/bans', $bearer, $queryParamsMap, $bodyParamsMap);
     }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#unban-user
+     */
+    public function unbanUser(string $bearer, string $broadcasterId, string $moderatorId, string $userId): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+        $queryParamsMap[] = ['key' => 'user_id', 'value' => $userId];
+
+        return $this->deleteApi('moderation/bans', $bearer, $queryParamsMap);
+    }
 }

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -9,30 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 
 class ModerationApi extends AbstractResource
 {
-    /**
-     * @throws GuzzleException
-     * @link https://dev.twitch.tv/docs/api/reference/#get-banned-events
-     */
-    public function getBannedEvents(string $bearer, string $broadcasterId, array $ids = [], string $first = null, string $after = null): ResponseInterface
-    {
-        $queryParamsMap = [];
-
-        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
-
-        foreach ($ids as $id) {
-            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-        }
-
-        if ($first) {
-            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
-        }
-
-        if ($after) {
-            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-        }
-
-        return $this->getApi('moderation/banned/events', $bearer, $queryParamsMap);
-    }
 
     /**
      * @throws GuzzleException
@@ -78,27 +54,6 @@ class ModerationApi extends AbstractResource
         }
 
         return $this->getApi('moderation/moderators', $bearer, $queryParamsMap);
-    }
-
-    /**
-     * @throws GuzzleException
-     * @link https://dev.twitch.tv/docs/api/reference/#get-moderator-events
-     */
-    public function getModeratorEvents(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
-    {
-        $queryParamsMap = [];
-
-        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
-
-        foreach ($ids as $id) {
-            $queryParamsMap[] = ['key' => 'user_id', 'value' => $id];
-        }
-
-        if ($after) {
-            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
-        }
-
-        return $this->getApi('moderation/moderators/events', $bearer, $queryParamsMap);
     }
 
     /**

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -122,4 +122,86 @@ class ModerationApi extends AbstractResource
 
         return $this->deleteApi('moderation/bans', $bearer, $queryParamsMap);
     }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-automod-settings
+     */
+    public function getAutoModSettings(string $bearer, string $broadcasterId, string $moderatorId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+
+        return $this->getApi('moderation/automod/settings', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#update-automod-settings
+     */
+    public function updateAutoModSettings(string $bearer, string $broadcasterId, string $moderatorId, array $settings): ResponseInterface
+    {
+        $queryParamsMap = $bodyParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+
+        foreach ($settings as $key => $value) {
+            $bodyParamsMap[] = ['key' => $key, 'value' => $value];
+        }
+
+        return $this->putApi('moderation/automod/settings', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#get-blocked-terms
+     */
+    public function getBlockedTerms(string $bearer, string $broadcasterId, string $moderatorId, int $first = null, string $after = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($after) {
+            $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        return $this->getApi('moderation/blocked_terms', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#add-blocked-term
+     */
+    public function addBlockedTerm(string $bearer, string $broadcasterId, string $moderatorId, string $term): ResponseInterface
+    {
+        $queryParamsMap = $bodyParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+
+        $bodyParamsMap[] = ['key' => 'term', 'value' => $term];
+
+        return $this->postApi('moderation/blocked_terms', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#remove-blocked-term
+     */
+    public function removeBlockedTerm(string $bearer, string $broadcasterId, string $moderatorId, string $termId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+        $queryParamsMap[] = ['key' => 'id', 'value' => $termId];
+        
+        return $this->deleteApi('moderation/blocked_terms', $bearer, $queryParamsMap);
+    }
 }

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -201,7 +201,24 @@ class ModerationApi extends AbstractResource
         $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
         $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
         $queryParamsMap[] = ['key' => 'id', 'value' => $termId];
-        
+
         return $this->deleteApi('moderation/blocked_terms', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#delete-chat-messages
+     */
+    public function deleteChatMessages(string $bearer, string $broadcasterId, string $moderatorId, string $messageId = null): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+        $queryParamsMap[] = ['key' => 'moderator_id', 'value' => $moderatorId];
+        
+        if ($messageId) {
+            $queryParamsMap[] = ['key' => 'message_id', 'value' => $messageId];
+        }
+
+        return $this->deleteApi('moderation/chat', $bearer, $queryParamsMap);
     }
 }

--- a/src/Resources/RaidsApi.php
+++ b/src/Resources/RaidsApi.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class RaidsApi extends AbstractResource
+{
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#start-a-raid
+     */
+    public function startRaid(string $bearer, string $fromBroadcasterId, string $toBroadcasterId): ResponseInterface
+    {
+        $queryParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'from_broadcaster_id', 'value' => $fromBroadcasterId];
+        $queryParamsMap[] = ['key' => 'to_broadcaster_id', 'value' => $toBroadcasterId];
+
+        return $this->postApi('raids', $bearer, $queryParamsMap);
+    }
+
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#cancel-a-raid
+     */
+    public function cancelRaid(string $bearer, string $toBroadcasterId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $toBroadcasterId];
+
+        return $this->deleteApi('raids', $bearer, $queryParamsMap);
+    }
+}

--- a/src/Resources/WhispersApi.php
+++ b/src/Resources/WhispersApi.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class WhispersApi extends AbstractResource
+{
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference#send-whisper
+     */
+    public function sendWhisper(string $bearer, string $fromUserId, string $toUserId, string $message): ResponseInterface
+    {
+        $queryParamsMap = $bodyParamsMap = [];
+
+        $queryParamsMap[] = ['key' => 'from_user_id', 'value' => $fromUserId];
+        $queryParamsMap[] = ['key' => 'to_user_id', 'value' => $toUserId];
+
+        $bodyParamsMap[] = ['key' => 'message', 'value' => $message];
+
+        return $this->postApi('whispers', $bearer, $queryParamsMap, $bodyParamsMap);
+    }
+}

--- a/src/TwitchApi.php
+++ b/src/TwitchApi.php
@@ -30,6 +30,7 @@ use TwitchApi\Resources\TeamsApi;
 use TwitchApi\Resources\UsersApi;
 use TwitchApi\Resources\VideosApi;
 use TwitchApi\Resources\WebhooksApi;
+use TwitchApi\Resources\WhispersApi;
 use TwitchApi\Webhooks\WebhooksSubscriptionApi;
 
 class TwitchApi
@@ -59,6 +60,7 @@ class TwitchApi
     private $usersApi;
     private $videosApi;
     private $webhooksApi;
+    private $whispersApi;
     private $webhooksSubscriptionApi;
 
     public function __construct(HelixGuzzleClient $helixGuzzleClient, string $clientId, string $clientSecret, Client $authGuzzleClient = null)
@@ -89,6 +91,7 @@ class TwitchApi
         $this->usersApi = new UsersApi($helixGuzzleClient, $requestGenerator);
         $this->videosApi = new VideosApi($helixGuzzleClient, $requestGenerator);
         $this->webhooksApi = new WebhooksApi($helixGuzzleClient, $requestGenerator);
+        $this->whispersApi = new WhispersApi($helixGuzzleClient, $requestGenerator);
         $this->webhooksSubscriptionApi = new WebhooksSubscriptionApi($clientId, $clientSecret, $helixGuzzleClient);
     }
 
@@ -215,6 +218,11 @@ class TwitchApi
     public function getWebhooksApi(): WebhooksApi
     {
         return $this->webhooksApi;
+    }
+
+    public function getWhispersApi(): WhispersApi
+    {
+        return $this->whispersApi;
     }
 
     public function getWebhooksSubscriptionApi(): WebhooksSubscriptionApi

--- a/src/TwitchApi.php
+++ b/src/TwitchApi.php
@@ -20,6 +20,7 @@ use TwitchApi\Resources\HypeTrainApi;
 use TwitchApi\Resources\ModerationApi;
 use TwitchApi\Resources\PollsApi;
 use TwitchApi\Resources\PredictionsApi;
+use TwitchApi\Resources\RaidsApi;
 use TwitchApi\Resources\ScheduleApi;
 use TwitchApi\Resources\SearchApi;
 use TwitchApi\Resources\StreamsApi;
@@ -48,6 +49,7 @@ class TwitchApi
     private $moderationApi;
     private $pollsApi;
     private $predictionsApi;
+    private $raidsApi;
     private $scheduleApi;
     private $searchApi;
     private $streamsApi;
@@ -77,6 +79,7 @@ class TwitchApi
         $this->moderationApi = new ModerationApi($helixGuzzleClient, $requestGenerator);
         $this->pollsApi = new PollsApi($helixGuzzleClient, $requestGenerator);
         $this->predictionsApi = new PredictionsApi($helixGuzzleClient, $requestGenerator);
+        $this->raidsApi = new RaidsApi($helixGuzzleClient, $requestGenerator);
         $this->scheduleApi = new ScheduleApi($helixGuzzleClient, $requestGenerator);
         $this->searchApi = new SearchApi($helixGuzzleClient, $requestGenerator);
         $this->streamsApi = new StreamsApi($helixGuzzleClient, $requestGenerator);
@@ -162,6 +165,11 @@ class TwitchApi
     public function getPredictionsApi(): PredictionsApi
     {
         return $this->predictionsApi;
+    }
+
+    public function getRaidsApi(): RaidsApi
+    {
+        return $this->raidsApi;
     }
 
     public function getScheduleApi(): ScheduleApi


### PR DESCRIPTION
**BREAKING CHANGES**
- Removed `getBannedEvents` and `getModeratorEvents` - [Announcement](https://discuss.dev.twitch.tv/t/deprecation-of-twitch-api-event-endpoints-that-supported-websub-based-webhooks/35137)
- Removed `id` parameter from `getHypeTrainEvents` (this function was broken anyways) - [Announcement](https://discuss.dev.twitch.tv/t/get-hype-train-events-api-endpoint-id-query-parameter-deprecation/37613)
- Removed `user_id` parameter from `checkAutoModStatus` - [Announcement](https://discuss.dev.twitch.tv/t/upcoming-changes-to-the-check-automod-status-api-endpoint/38512)

**CHANGES**
- Promoted `EventSub` -> `extension.bits_transaction.crate` to version `1`

**NEW FEATURES**
- Added `user_id` parameter to `getEventSubSubscription`
- Added `ChatApi` -> `getChatSettings`
- Added `ChatApi` -> `updateChatSettings`
- Added `ChatApi` -> `sendChatAnnouncement`
- Added `ChatApi` -> `getUserChatColor`
- Added `ChatApi` -> `updateUserChatColor`
- Added `EventSub` -> `user.authorization.grant`
- Added `EventSub` -> `channel.goal.begin`
- Added `EventSub` -> `channel.goal.progress`
- Added `EventSub` -> `channel.goal.end`
- Added `ModerationApi` -> `banUser`
- Added `ModerationApi` -> `unbanUser`
- Added `ModerationApi` -> `getAutoModSettings`
- Added `ModerationApi` -> `updateAutoModSettings`
- Added `ModerationApi` -> `getBlockedTerms`
- Added `ModerationApi` -> `addBlockedTerm`
- Added `ModerationApi` -> `removeBlockedTerm`
- Added `ModerationApi` -> `deleteChatMessages`
- Added `ModerationApi` -> `addChannelModerator`
- Added `ModerationApi` -> `removeChannelModerator`
- Added `ModerationApi` -> `getVips`
- Added `ModerationApi` -> `addChannelVip`
- Added `ModerationApi` -> `removeChannelVip`
- Added `RaidsApi`
- Added `RaidsApi` -> `startRaid`
- Added `RaidsApi` -> `cancelRaid`
- Added `WhispersApi`
- Added `WhispersApi` -> `sendWhisper`