### PR TITLE
Finish Endpoint and Testing Coverage

### DIFF
--- a/spec/TwitchApi/Resources/BitsApiSpec.php
+++ b/spec/TwitchApi/Resources/BitsApiSpec.php
@@ -51,4 +51,16 @@ class BitsApiSpec extends ObjectBehavior
         $requestGenerator->generate('GET', 'extensions/transactions', 'TEST_TOKEN', [['key' => 'extension_id', 'value' => '1'], ['key' => 'after', 'value' => '100']], [])->willReturn($request);
         $this->getExtensionTransactions('TEST_TOKEN', '1', [], null, 100)->shouldBe($response);
     }
+
+    function it_should_get_bits_leaderboard(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'bits/leaderboard', 'TEST_TOKEN', [], [])->willReturn($request);
+        $this->getBitsLeaderboard('TEST_TOKEN')->shouldBe($response);
+    }
+
+    function it_should_get_bits_leaderboard_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'bits/leaderboard', 'TEST_TOKEN', [['key' => 'count', 'value' => '100'], ['key' => 'period', 'value' => 'all'], ['key' => 'started_at', 'value' => '2019-10-12T07:20:50.52Z'], ['key' => 'user_id', 'value' => '123']], [])->willReturn($request);
+        $this->getBitsLeaderboard('TEST_TOKEN', 100, 'all', '2019-10-12T07:20:50.52Z', '123')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/ClipsApiSpec.php
+++ b/spec/TwitchApi/Resources/ClipsApiSpec.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace spec\TwitchApi\Resources;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TwitchApi\RequestGenerator;
+use TwitchApi\HelixGuzzleClient;
+use PhpSpec\ObjectBehavior;
+
+class ClipsApiSpec extends ObjectBehavior
+{
+    function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->beConstructedWith($guzzleClient, $requestGenerator);
+        $guzzleClient->send($request)->willReturn($response);
+    }
+
+    function it_should_get_clips_by_broadcaster_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getClips('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_clips_by_broadcaster_id_with_helper_function(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getClipsByBroadcasterId('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_clips_by_game_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'game_id', 'value' => '123']], [])->willReturn($request);
+        $this->getClips('TEST_TOKEN', null, '123')->shouldBe($response);
+    }
+
+    function it_should_get_clips_by_game_id_with_helper_function(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'game_id', 'value' => '123']], [])->willReturn($request);
+        $this->getClipsByGameId('TEST_TOKEN', '123')->shouldBe($response);
+    }
+    
+    function it_should_get_one_clip_by_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'id', 'value' => '123']], [])->willReturn($request);
+        $this->getClips('TEST_TOKEN', null, null, '123')->shouldBe($response);
+    }
+
+    function it_should_get_one_clip_by_id_with_helper_function(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'id', 'value' => '123']], [])->willReturn($request);
+        $this->getClipsByIds('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_multiple_clips_by_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'id', 'value' => '123,456']], [])->willReturn($request);
+        $this->getClips('TEST_TOKEN', null, null, '123,456')->shouldBe($response);
+    }
+
+    function it_should_get_multiple_clips_by_id_with_helper_function(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'id', 'value' => '123,456']], [])->willReturn($request);
+        $this->getClipsByIds('TEST_TOKEN', '123,456')->shouldBe($response);
+    }
+
+    function it_should_get_clips_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'clips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'first', 'value' => '10'], ['key' => 'before', 'value' => 'abc'], ['key' => 'after', 'value' => 'def'], ['key' => 'started_at', 'value' => '2018-10-12T07:20:50.52Z'], ['key' => 'ended_at', 'value' => '2019-10-12T07:20:50.52Z']], [])->willReturn($request);
+        $this->getClips('TEST_TOKEN', '123', null, null, 10, 'abc', 'def', '2018-10-12T07:20:50.52Z', '2019-10-12T07:20:50.52Z')->shouldBe($response);
+    }
+
+    function it_should_create_a_clip(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('POST', 'clips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'has_delay', 'value' => 'true']], [])->willReturn($request);
+        $this->createClip('TEST_TOKEN', '123', true)->shouldBe($response);
+    }
+}

--- a/spec/TwitchApi/Resources/EntitlementsApiSpec.php
+++ b/spec/TwitchApi/Resources/EntitlementsApiSpec.php
@@ -81,4 +81,22 @@ class EntitlementsApiSpec extends ObjectBehavior
         $requestGenerator->generate('POST', 'entitlements/code', 'TEST_TOKEN', [['key' => 'user_id', 'value' => '123'], ['key' => 'code', 'value' => 'abc'], ['key' => 'code', 'value' => 'def']], [])->willReturn($request);
         $this->redeemCode('TEST_TOKEN', '123', ['abc', 'def'])->shouldBe($response);
     }
+
+    function it_should_update_drop_entitlements(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PATCH', 'entitlements/drops', 'TEST_TOKEN', [], [])->willReturn($request);
+        $this->updateDropsEntitlements('TEST_TOKEN')->shouldBe($response);
+    }
+
+    function it_should_update_one_drop_entitlements(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PATCH', 'entitlements/drops', 'TEST_TOKEN', [], [['key' => 'entitlement_ids', 'value' => ['123']], ['key' => 'fulfillment_status', 'value' => 'FULFILLED']])->willReturn($request);
+        $this->updateDropsEntitlements('TEST_TOKEN', ['123'], 'FULFILLED')->shouldBe($response);
+    }
+
+    function it_should_update_multiple_drop_entitlements(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('PATCH', 'entitlements/drops', 'TEST_TOKEN', [], [['key' => 'entitlement_ids', 'value' => ['123', '456']], ['key' => 'fulfillment_status', 'value' => 'FULFILLED']])->willReturn($request);
+        $this->updateDropsEntitlements('TEST_TOKEN', ['123', '456'], 'FULFILLED')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/TwitchApi/Resources/EventSubApiSpec.php
@@ -288,4 +288,16 @@ class EventSubApiSpec extends ObjectBehavior
         $this->createEventSubSubscription('channel.goal.end', '1', ['broadcaster_user_id' => '12345'], $requestGenerator)->willReturn($request);
         $this->subscribeToChannelGoalEnd($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
     }
+
+    function it_should_subscribe_to_drop_entitelement_grant(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->createEventSubSubscription('drop.entitlement.grant', '1', ['organization_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->subscribeToDropEntitlementGrant($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
+    }
+
+    function it_should_subscribe_to_drop_entitelement_grant_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->createEventSubSubscription('drop.entitlement.grant', '1', ['organization_id' => '123', 'category_id' => '456', 'campaign_id' => '789'], $requestGenerator)->willReturn($request);
+        $this->subscribeToDropEntitlementGrant($this->bearer, $this->secret, $this->callback, '123', '456', '789')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/ModerationApiSpec.php
+++ b/spec/TwitchApi/Resources/ModerationApiSpec.php
@@ -147,4 +147,28 @@ class ModerationApiSpec extends ObjectBehavior
         $requestGenerator->generate('DELETE', 'channels/vips', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => '456']], [])->willReturn($request);
         $this->removeChannelVip('TEST_TOKEN', '123', '456')->shouldBe($response);
     }
+
+    function it_should_get_banned_users(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'moderation/banned', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getBannedUsers('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_banned_users_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'moderation/banned', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => 'abc'], ['key' => 'user_id', 'value' => 'def'], ['key' => 'before', 'value' => 'abc'], ['key' => 'after', 'value' => 'def'], ['key' => 'first', 'value' => '100']], [])->willReturn($request);
+        $this->getBannedUsers('TEST_TOKEN', '123', ['abc', 'def'], 'abc', 'def', '100')->shouldBe($response);
+    }
+
+    function it_should_get_moderators(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'moderation/moderators', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getModerators('TEST_TOKEN', '123')->shouldBe($response);
+    }
+
+    function it_should_get_moderators_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'moderation/moderators', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123'], ['key' => 'user_id', 'value' => 'abc'], ['key' => 'user_id', 'value' => 'def'], ['key' => 'after', 'value' => 'abc'], ['key' => 'first', 'value' => '100']], [])->willReturn($request);
+        $this->getModerators('TEST_TOKEN', '123', ['abc', 'def'], 'abc', '100')->shouldBe($response);
+    }
 }

--- a/spec/TwitchApi/Resources/SearchApiSpec.php
+++ b/spec/TwitchApi/Resources/SearchApiSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\TwitchApi\Resources;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TwitchApi\RequestGenerator;
+use TwitchApi\HelixGuzzleClient;
+use PhpSpec\ObjectBehavior;
+
+class SearchApiSpec extends ObjectBehavior
+{
+    function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->beConstructedWith($guzzleClient, $requestGenerator);
+        $guzzleClient->send($request)->willReturn($response);
+    }
+
+    function it_should_search_categories(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'search/categories', 'TEST_TOKEN', [['key' => 'query', 'value' => 'test']], [])->willReturn($request);
+        $this->searchCategories('TEST_TOKEN', 'test')->shouldBe($response);
+    }
+
+    function it_should_search_categories_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'search/categories', 'TEST_TOKEN', [['key' => 'query', 'value' => 'test'], ['key' => 'first', 'value' => 100], ['key' => 'after', 'value' => 'abc']], [])->willReturn($request);
+        $this->searchCategories('TEST_TOKEN', 'test', 100, 'abc')->shouldBe($response);
+    }
+
+    function it_should_search_channels(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'search/channels', 'TEST_TOKEN', [['key' => 'query', 'value' => 'test']], [])->willReturn($request);
+        $this->searchChannels('TEST_TOKEN', 'test')->shouldBe($response);
+    }
+
+    function it_should_search_channels_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'search/channels', 'TEST_TOKEN', [['key' => 'query', 'value' => 'test'], ['key' => 'live_only', 'value' => true], ['key' => 'first', 'value' => 100], ['key' => 'after', 'value' => 'abc']], [])->willReturn($request);
+        $this->searchChannels('TEST_TOKEN', 'test', true, 100, 'abc')->shouldBe($response);
+    }
+}

--- a/spec/TwitchApi/TwitchApiSpec.php
+++ b/spec/TwitchApi/TwitchApiSpec.php
@@ -10,6 +10,8 @@ use TwitchApi\Resources\AnalyticsApi;
 use TwitchApi\Resources\BitsApi;
 use TwitchApi\Resources\ChannelPointsApi;
 use TwitchApi\Resources\ChannelsApi;
+use TwitchApi\Resources\ChatApi;
+use TwitchApi\Resources\ClipsApi;
 use TwitchApi\Resources\EntitlementsApi;
 use TwitchApi\Resources\EventSubApi;
 use TwitchApi\Resources\GamesApi;
@@ -19,6 +21,7 @@ use TwitchApi\Resources\PollsApi;
 use TwitchApi\Resources\PredictionsApi;
 use TwitchApi\Resources\RaidsApi;
 use TwitchApi\Resources\ScheduleApi;
+use TwitchApi\Resources\SearchApi;
 use TwitchApi\Resources\StreamsApi;
 use TwitchApi\Resources\SubscriptionsApi;
 use TwitchApi\Resources\TagsApi;
@@ -67,6 +70,16 @@ class TwitchApiSpec extends ObjectBehavior
         $this->getChannelsApi()->shouldBeAnInstanceOf(ChannelsApi::class);
     }
 
+    function it_should_provide_chat_api()
+    {
+        $this->getChatApi()->shouldBeAnInstanceOf(ChatApi::class);
+    }
+
+    function it_should_provide_clips_api()
+    {
+        $this->getClipsApi()->shouldBeAnInstanceOf(ClipsApi::class);
+    }
+
     function it_should_provide_entitlements_api()
     {
         $this->getEntitlementsApi()->shouldBeAnInstanceOf(EntitlementsApi::class);
@@ -111,14 +124,19 @@ class TwitchApiSpec extends ObjectBehavior
         $this->getScheduleApi()->shouldBeAnInstanceOf(ScheduleApi::class);
     }
 
-    function it_should_provide_subscriptions_api()
+    function it_should_provide_search_api()
     {
-        $this->getSubscriptionsApi()->shouldBeAnInstanceOf(SubscriptionsApi::class);
+        $this->getSearchApi()->shouldBeAnInstanceOf(SearchApi::class);
     }
 
     function it_should_provide_streams_api()
     {
         $this->getStreamsApi()->shouldBeAnInstanceOf(StreamsApi::class);
+    }
+
+    function it_should_provide_subscriptions_api()
+    {
+        $this->getSubscriptionsApi()->shouldBeAnInstanceOf(SubscriptionsApi::class);
     }
 
     function it_should_provide_tags_api()

--- a/src/Resources/EntitlementsApi.php
+++ b/src/Resources/EntitlementsApi.php
@@ -78,8 +78,13 @@ class EntitlementsApi extends AbstractResource
     {
         $bodyParamsMap = [];
 
-        $bodyParamsMap[] = ['key' => 'entitlement_ids', 'value' => $entitlement_ids];
-        $bodyParamsMap[] = ['key' => 'fulfillment_status', 'value' => $fulfillment_status];
+        if ($entitlement_ids) {
+            $bodyParamsMap[] = ['key' => 'entitlement_ids', 'value' => $entitlement_ids];
+        }
+
+        if ($fulfillment_status) {
+            $bodyParamsMap[] = ['key' => 'fulfillment_status', 'value' => $fulfillment_status];
+        }
 
         return $this->patchApi('entitlements/drops', $bearer, [], $bodyParamsMap);
     }

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -444,6 +444,29 @@ class EventSubApi extends AbstractResource
     }
 
     /**
+     * @link https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#dropentitlementgrant
+     */
+    public function subscribeToDropEntitlementGrant(string $bearer, string $secret, string $callback, string $organizationId, string $categoryId = null, string $campaign_id = null): ResponseInterface
+    {
+        $condition = ['organization_id' => $organizationId];
+        if ($categoryId) {
+            $condition['category_id'] = $categoryId;
+        }
+        if ($campaign_id) {
+            $condition['campaign_id'] = $campaign_id;
+        }
+
+        return $this->createEventSubSubscription(
+            $bearer,
+            $secret,
+            $callback,
+            'drop.entitlement.grant',
+            '1',
+            $condition,
+        );
+    }
+
+    /**
      * @link https://dev.twitch.tv/docs/eventsub#verify-a-signature
      */
     public function verifySignature(string $signature, string $secret, string $messageId, string $timestamp, string $body): bool

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -13,7 +13,7 @@ class ModerationApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-banned-users
      */
-    public function getBannedUsers(string $bearer, string $broadcasterId, array $ids = [], string $before = null, string $after = null): ResponseInterface
+    public function getBannedUsers(string $bearer, string $broadcasterId, array $ids = [], string $before = null, string $after = null, string $first = null): ResponseInterface
     {
         $queryParamsMap = [];
 
@@ -29,6 +29,10 @@ class ModerationApi extends AbstractResource
 
         if ($after) {
             $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
         }
 
         return $this->getApi('moderation/banned', $bearer, $queryParamsMap);

--- a/src/Resources/ModerationApi.php
+++ b/src/Resources/ModerationApi.php
@@ -42,7 +42,7 @@ class ModerationApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference/#get-moderators
      */
-    public function getModerators(string $bearer, string $broadcasterId, array $ids = [], string $after = null): ResponseInterface
+    public function getModerators(string $bearer, string $broadcasterId, array $ids = [], string $after = null, string $first = null): ResponseInterface
     {
         $queryParamsMap = [];
 
@@ -54,6 +54,10 @@ class ModerationApi extends AbstractResource
 
         if ($after) {
             $queryParamsMap[] = ['key' => 'after', 'value' => $after];
+        }
+
+        if ($first) {
+            $queryParamsMap[] = ['key' => 'first', 'value' => $first];
         }
 
         return $this->getApi('moderation/moderators', $bearer, $queryParamsMap);


### PR DESCRIPTION
I added a note to #136, since there have been no requests for the Extensions category yet, and this isn't likely to be needed in a PHP project, I'll consider endpoint coverage complete with this PR. [[Note]](https://github.com/nicklaw5/twitch-api-php/issues/136#issuecomment-1237225319)

# Changes
- `updateDropEntitlements` now allows you to specify no parameters, in line with the API Docs
- Added Missing Testing Coverage for many older functions

# New Features 
- Added `first` parameter to `getBannedUsers`
- Added `first` parameter to `getModerators`
- Added `EventSub` -> `drop.entitlement.grant`