### PR TITLE
Add in Goals API

### DIFF
--- a/spec/TwitchApi/Resources/GoalsApiSpec.php
+++ b/spec/TwitchApi/Resources/GoalsApiSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\TwitchApi\Resources;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use TwitchApi\RequestGenerator;
+use TwitchApi\HelixGuzzleClient;
+use PhpSpec\ObjectBehavior;
+
+class GoalsApiSpec extends ObjectBehavior
+{
+    function let(HelixGuzzleClient $guzzleClient, RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $this->beConstructedWith($guzzleClient, $requestGenerator);
+        $guzzleClient->send($request)->willReturn($response);
+    }
+
+    function it_should_get_goals_by_broadcaster_id(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'goals', 'TEST_TOKEN', [['key' => 'broadcaster_id', 'value' => '123']], [])->willReturn($request);
+        $this->getGoals('TEST_TOKEN', ['123'])->shouldBe($response);
+    }
+
+}

--- a/spec/TwitchApi/TwitchApiSpec.php
+++ b/spec/TwitchApi/TwitchApiSpec.php
@@ -16,6 +16,7 @@ use TwitchApi\Resources\ClipsApi;
 use TwitchApi\Resources\EntitlementsApi;
 use TwitchApi\Resources\EventSubApi;
 use TwitchApi\Resources\GamesApi;
+use TwitchApi\Resources\GoalsApi;
 use TwitchApi\Resources\HypeTrainApi;
 use TwitchApi\Resources\ModerationApi;
 use TwitchApi\Resources\PollsApi;
@@ -99,6 +100,11 @@ class TwitchApiSpec extends ObjectBehavior
     function it_should_provide_games_api()
     {
         $this->getGamesApi()->shouldBeAnInstanceOf(GamesApi::class);
+    }
+
+    function it_should_provide_goals_api()
+    {
+        $this->getGoalsApi()->shouldBeAnInstanceOf(GoalsApi::class);
     }
 
     function it_should_provide_hype_train_api() {

--- a/src/Resources/GoalsApi.php
+++ b/src/Resources/GoalsApi.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwitchApi\Resources;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class GoalsApi extends AbstractResource
+{
+    /**
+     * @throws GuzzleException
+     * @link https://dev.twitch.tv/docs/api/reference/#get-creator-goals
+     */
+    public function getGoals(string $bearer, string $broadcasterId): ResponseInterface
+    {
+        $queryParamsMap = [];
+        $queryParamsMap[] = ['key' => 'broadcaster_id', 'value' => $broadcasterId];
+
+        return $this->getApi('goals', $bearer, $queryParamsMap);
+    }
+}

--- a/src/TwitchApi.php
+++ b/src/TwitchApi.php
@@ -17,6 +17,7 @@ use TwitchApi\Resources\ClipsApi;
 use TwitchApi\Resources\EntitlementsApi;
 use TwitchApi\Resources\EventSubApi;
 use TwitchApi\Resources\GamesApi;
+use TwitchApi\Resources\GoalsApi;
 use TwitchApi\Resources\HypeTrainApi;
 use TwitchApi\Resources\ModerationApi;
 use TwitchApi\Resources\PollsApi;
@@ -48,6 +49,7 @@ class TwitchApi
     private $entitlementsApi;
     private $eventSubApi;
     private $gamesApi;
+    private $goalsApi;
     private $hypeTrainApi;
     private $moderationApi;
     private $pollsApi;
@@ -80,6 +82,7 @@ class TwitchApi
         $this->entitlementsApi = new EntitlementsApi($helixGuzzleClient, $requestGenerator);
         $this->eventSubApi = new EventSubApi($helixGuzzleClient, $requestGenerator);
         $this->gamesApi = new GamesApi($helixGuzzleClient, $requestGenerator);
+        $this->goalsApi = new GoalsApi($helixGuzzleClient, $requestGenerator);
         $this->hypeTrainApi = new HypeTrainApi($helixGuzzleClient, $requestGenerator);
         $this->moderationApi = new ModerationApi($helixGuzzleClient, $requestGenerator);
         $this->pollsApi = new PollsApi($helixGuzzleClient, $requestGenerator);
@@ -156,6 +159,11 @@ class TwitchApi
     public function getGamesApi(): GamesApi
     {
         return $this->gamesApi;
+    }
+
+    public function getGoalsApi(): GoalsApi
+    {
+        return $this->goalsApi;
     }
 
     public function getHypeTrainApi(): HypeTrainApi


### PR DESCRIPTION
Feature addition for the simple [goals endpoint](https://dev.twitch.tv/docs/api/reference#get-creator-goals).

Example:

`$response = $twitchApi->getGoalsApi()->getGoals($twitch_access_token, $twitch_broadcaster_id);`

Note: The Twitch API docs labels this endpoint as "Get Creator Goals", but the endpoint itself is just goals, so I went with "Goals" instead of "CreatorGoals". 