### PR TITLE
drop.entitlement.grant subscription must have is_batching_enabled param

### DIFF
--- a/spec/TwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/TwitchApi/Resources/EventSubApiSpec.php
@@ -14,20 +14,25 @@ class EventSubApiSpec extends ObjectBehavior
     private string $secret = 'SECRET';
     private string $callback = 'https://example.com/';
 
-    private function createEventSubSubscription(string $type, string $version, array $condition, RequestGenerator $requestGenerator, bool $isBatchingEnabled = false)
+    private function createEventSubSubscription(string $type, string $version, array $condition, RequestGenerator $requestGenerator, bool $isBatchingEnabled = null)
     {
         $bodyParams = [];
 
         $bodyParams[] = ['key' => 'type', 'value' => $type];
         $bodyParams[] = ['key' => 'version', 'value' => $version];
         $bodyParams[] = ['key' => 'condition', 'value' => $condition];
-        $bodyParams[] = ['key' => 'is_batching_enabled', 'value' => $isBatchingEnabled];
-        $bodyParams[] = ['key' => 'transport', 'value' => [
-          'method' => 'webhook',
-          'callback' => $this->callback,
-          'secret' => $this->secret,
-          ]
+        $bodyParams[] = [
+            'key' => 'transport',
+            'value' => [
+                'method' => 'webhook',
+                'callback' => $this->callback,
+                'secret' => $this->secret,
+            ],
         ];
+
+        if (null !== $isBatchingEnabled) {
+            $bodyParams[] = ['key' => 'is_batching_enabled', 'value' => $isBatchingEnabled];
+        }
 
         return $requestGenerator->generate('POST', 'eventsub/subscriptions', $this->bearer, [], $bodyParams);
     }

--- a/spec/TwitchApi/Resources/EventSubApiSpec.php
+++ b/spec/TwitchApi/Resources/EventSubApiSpec.php
@@ -14,13 +14,14 @@ class EventSubApiSpec extends ObjectBehavior
     private string $secret = 'SECRET';
     private string $callback = 'https://example.com/';
 
-    private function createEventSubSubscription(string $type, string $version, array $condition, RequestGenerator $requestGenerator)
+    private function createEventSubSubscription(string $type, string $version, array $condition, RequestGenerator $requestGenerator, bool $isBatchingEnabled = false)
     {
         $bodyParams = [];
 
         $bodyParams[] = ['key' => 'type', 'value' => $type];
         $bodyParams[] = ['key' => 'version', 'value' => $version];
         $bodyParams[] = ['key' => 'condition', 'value' => $condition];
+        $bodyParams[] = ['key' => 'is_batching_enabled', 'value' => $isBatchingEnabled];
         $bodyParams[] = ['key' => 'transport', 'value' => [
           'method' => 'webhook',
           'callback' => $this->callback,
@@ -291,13 +292,13 @@ class EventSubApiSpec extends ObjectBehavior
 
     function it_should_subscribe_to_drop_entitelement_grant(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $this->createEventSubSubscription('drop.entitlement.grant', '1', ['organization_id' => '12345'], $requestGenerator)->willReturn($request);
+        $this->createEventSubSubscription('drop.entitlement.grant', '1', ['organization_id' => '12345'], $requestGenerator, true)->willReturn($request);
         $this->subscribeToDropEntitlementGrant($this->bearer, $this->secret, $this->callback, '12345')->shouldBe($response);
     }
 
     function it_should_subscribe_to_drop_entitelement_grant_with_opts(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
-        $this->createEventSubSubscription('drop.entitlement.grant', '1', ['organization_id' => '123', 'category_id' => '456', 'campaign_id' => '789'], $requestGenerator)->willReturn($request);
+        $this->createEventSubSubscription('drop.entitlement.grant', '1', ['organization_id' => '123', 'category_id' => '456', 'campaign_id' => '789'], $requestGenerator, true)->willReturn($request);
         $this->subscribeToDropEntitlementGrant($this->bearer, $this->secret, $this->callback, '123', '456', '789')->shouldBe($response);
     }
 

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -40,13 +40,14 @@ class EventSubApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#create-eventsub-subscription
      */
-    public function createEventSubSubscription(string $bearer, string $secret, string $callback, string $type, string $version, array $condition): ResponseInterface
+    public function createEventSubSubscription(string $bearer, string $secret, string $callback, string $type, string $version, array $condition, bool $isBatchingEnabled = false): ResponseInterface
     {
         $bodyParams = [];
 
         $bodyParams[] = ['key' => 'type', 'value' => $type];
         $bodyParams[] = ['key' => 'version', 'value' => $version];
         $bodyParams[] = ['key' => 'condition', 'value' => $condition];
+        $bodyParams[] = ['key' => 'is_batching_enabled', 'value' => $isBatchingEnabled];
         $bodyParams[] = [
             'key' => 'transport',
             'value' => [
@@ -511,6 +512,7 @@ class EventSubApi extends AbstractResource
             'drop.entitlement.grant',
             '1',
             $condition,
+            true
         );
     }
 

--- a/src/Resources/EventSubApi.php
+++ b/src/Resources/EventSubApi.php
@@ -40,14 +40,13 @@ class EventSubApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#create-eventsub-subscription
      */
-    public function createEventSubSubscription(string $bearer, string $secret, string $callback, string $type, string $version, array $condition, bool $isBatchingEnabled = false): ResponseInterface
+    public function createEventSubSubscription(string $bearer, string $secret, string $callback, string $type, string $version, array $condition, bool $isBatchingEnabled = null): ResponseInterface
     {
         $bodyParams = [];
 
         $bodyParams[] = ['key' => 'type', 'value' => $type];
         $bodyParams[] = ['key' => 'version', 'value' => $version];
         $bodyParams[] = ['key' => 'condition', 'value' => $condition];
-        $bodyParams[] = ['key' => 'is_batching_enabled', 'value' => $isBatchingEnabled];
         $bodyParams[] = [
             'key' => 'transport',
             'value' => [
@@ -56,6 +55,10 @@ class EventSubApi extends AbstractResource
                 'secret' => $secret,
             ],
         ];
+
+        if (null !== $isBatchingEnabled) {
+            $bodyParams[] = ['key' => 'is_batching_enabled', 'value' => $isBatchingEnabled];
+        }
 
         return $this->postApi('eventsub/subscriptions', $bearer, [], $bodyParams);
     }


### PR DESCRIPTION
in case of subscription `drop.entitlement.grant` we must use `is_batching_enabled: true` param https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#drop-entitlement-grant-notification-example

otherwise will get an exception

```
{
    "error":"Bad Request",
    "status":400,
    "message":"is_batching_enabled must be true for drop.entitlement.grant subscriptions"
}
``` 