### PR TITLE
add FulfillmentStatus filter to getDropsEntitlements method

### DIFF
--- a/spec/TwitchApi/Resources/EntitlementsApiSpec.php
+++ b/spec/TwitchApi/Resources/EntitlementsApiSpec.php
@@ -70,6 +70,12 @@ class EntitlementsApiSpec extends ObjectBehavior
         $this->getDropsEntitlements('TEST_TOKEN', null, null, '123', 'abc', 100)->shouldBe($response);
     }
 
+    function it_should_get_drop_entitlements_by_status(RequestGenerator $requestGenerator, Request $request, Response $response)
+    {
+        $requestGenerator->generate('GET', 'entitlements/drops', 'TEST_TOKEN', [['key' => 'fulfillment_status', 'value' => 'CLAIMED']], [])->willReturn($request);
+        $this->getDropsEntitlements('TEST_TOKEN', null, null, null, null, null, 'CLAIMED')->shouldBe($response);
+    }
+
     function it_should_redeem_code(RequestGenerator $requestGenerator, Request $request, Response $response)
     {
         $requestGenerator->generate('POST', 'entitlements/code', 'TEST_TOKEN', [['key' => 'user_id', 'value' => '123'], ['key' => 'code', 'value' => 'abc']], [])->willReturn($request);

--- a/src/Resources/EntitlementsApi.php
+++ b/src/Resources/EntitlementsApi.php
@@ -43,7 +43,7 @@ class EntitlementsApi extends AbstractResource
      * @throws GuzzleException
      * @link https://dev.twitch.tv/docs/api/reference#get-drops-entitlements
      */
-    public function getDropsEntitlements(string $bearer, string $id = null, string $userId = null, string $gameId = null, string $after = null, int $first = null): ResponseInterface
+    public function getDropsEntitlements(string $bearer, string $id = null, string $userId = null, string $gameId = null, string $after = null, int $first = null, string $fulfillmentStatus = null): ResponseInterface
     {
         $queryParamsMap = [];
 
@@ -65,6 +65,10 @@ class EntitlementsApi extends AbstractResource
 
         if ($first) {
             $queryParamsMap[] = ['key' => 'first', 'value' => $first];
+        }
+
+        if ($fulfillmentStatus) {
+            $queryParamsMap[] = ['key' => 'fulfillment_status', 'value' => $fulfillmentStatus];
         }
 
         return $this->getApi('entitlements/drops', $bearer, $queryParamsMap);


### PR DESCRIPTION
add `fulfillment_status` filter to getDropsEntitlements method according to the doc https://dev.twitch.tv/docs/api/reference/#get-drops-entitlements

**note**:  ideally it should be after `$gameId` parameter, but i afraid to break compatibility